### PR TITLE
PLUME-18: Add functionspace to ModelData

### DIFF
--- a/src/plume/data/ModelData.cc
+++ b/src/plume/data/ModelData.cc
@@ -169,6 +169,20 @@ atlas::Field ModelData::getAtlasFieldShared(std::string name) const {
     return atlas::Field(entry->as<atlas::Field::Implementation*>());
 }
 
+// Get the function space
+// @note We want to move this logic elsewhere (ifs) if it is needed
+// the assumption is that all fields share the same function space
+// @todo Plume should consider function space as a separate type, not derive it from a field
+atlas::FunctionSpace ModelData::getAtlasFunctionSpace() const {
+    for (const auto& [name, entry] : valueMap_) {
+        if (entry->type() != ParameterType::ATLAS_FIELD) {
+            continue;
+        }
+        return getAtlasFieldShared(name).functionspace();
+    }
+    return atlas::FunctionSpace();
+}
+
 
 // Get a subset of the ModelData
 ModelData ModelData::filter(std::vector<std::string> params) const {

--- a/src/plume/data/ModelData.h
+++ b/src/plume/data/ModelData.h
@@ -18,6 +18,7 @@
 
 #include "eckit/value/Value.h"
 
+#include "atlas/functionspace.h"
 #include "atlas/field/Field.h"
 #include "atlas/field/detail/FieldImpl.h"
 
@@ -71,6 +72,7 @@ public:
 
     // -- shared data
     atlas::Field getAtlasFieldShared(std::string name) const;
+    atlas::FunctionSpace getAtlasFunctionSpace() const;
 
     // Return a subset of the ModelData
     ModelData filter(std::vector<std::string> params) const ;


### PR DESCRIPTION
This PR is a draft and is meant to discuss about the best way to pass the atlas function space without going through an arbitrary field, and settle on what we want to support for now (single or multiple function spaces allowed ?).
Once we reach an agreement this PR will need an ifs-source PR to modify the interface.