### PR TITLE
PLUME-30: plume_plugin_interface generates separate interface files for SP and DP

### DIFF
--- a/cmake/fortran_plugin.cc.in
+++ b/cmake/fortran_plugin.cc.in
@@ -8,7 +8,7 @@
  * granted to it by virtue of its status as an intergovernmental organisation nor
  * does it submit to any jurisdiction.
  */
-#include "fortran_plugin.h"
+#include "fortran_plugin@PREC_SUFFIX@.h"
 #include <iostream>
 
 

--- a/cmake/plume-plugin-interface.cmake
+++ b/cmake/plume-plugin-interface.cmake
@@ -25,6 +25,7 @@ function( plume_plugin_interface )
         PLUGIN_VERSION
         PLUGIN_SHA
         PLUGINCORE_NAME
+        PLUGIN_PRECISION
     )
 
     set(multi_value_args
@@ -42,6 +43,7 @@ function( plume_plugin_interface )
     set(PLUGIN_SHA ${_PAR_PLUGIN_SHA})
     set(PLUGINCORE_NAME ${_PAR_PLUGINCORE_NAME})
     set(PLUGIN_REQUIRED_PARAMS ${_PAR_PLUGIN_REQUIRED_PARAMS})
+    set(PLUGIN_PRECISION ${_PAR_PLUGIN_PRECISION})
 
     # list of required parameters
     set(REQUIRED_PARAM_LIST "")
@@ -65,36 +67,48 @@ function( plume_plugin_interface )
 
     get_filename_component( PLUGIN_TEMPLATE_FILENAME ${_PAR_PLUGIN_TEMPLATE} NAME)
     get_filename_component( GENERATED_USER_SOURCE_FILE ${_PAR_PLUGIN_TEMPLATE} NAME_WLE)
+    get_filename_component( GENERATED_USER_SOURCE_FILE_WEXT ${GENERATED_USER_SOURCE_FILE} NAME_WLE)
+
+    message(" ==>> GENERATED_USER_SOURCE_FILE: ${GENERATED_USER_SOURCE_FILE}")
     message("Plugin: ${PLUGIN_NAME}; PluginCore {PLUGINCORE_NAME}; Source: ${PLUGIN_TEMPLATE_FILENAME}")
+
+    # define finename suffix _PREC_SUFFIX if precision is set
+    if (PLUGIN_PRECISION)
+        set(PREC_SUFFIX "_${PLUGIN_PRECISION}")
+    else()
+        set(PREC_SUFFIX "")
+    endif()
+
+    SET(CONFIGURED_PLUGIN_FILENAME ${GENERATED_USER_SOURCE_FILE_WEXT}${PREC_SUFFIX}.F90)
 
     # pre-process user source-template
     ecbuild_configure_file(
         ${_PAR_PLUGIN_TEMPLATE}
-        ${GENERATED_USER_SOURCE_FILE} @ONLY
+        ${CONFIGURED_PLUGIN_FILENAME} @ONLY
     )
 
     # pre-process interface files
     ecbuild_configure_file(
         ${CMAKE_CURRENT_FUNCTION_LIST_DIR}/fortran_plugin.h.in
-        ${CMAKE_CURRENT_BINARY_DIR}/fortran_plugin.h @ONLY
+        ${CMAKE_CURRENT_BINARY_DIR}/fortran_plugin${PREC_SUFFIX}.h @ONLY
     )
 
     ecbuild_configure_file(
         ${CMAKE_CURRENT_FUNCTION_LIST_DIR}/fortran_plugin.cc.in
-        ${CMAKE_CURRENT_BINARY_DIR}/fortran_plugin.cc @ONLY
+        ${CMAKE_CURRENT_BINARY_DIR}/fortran_plugin${PREC_SUFFIX}.cc @ONLY
     )
 
     ecbuild_configure_file(
         ${CMAKE_CURRENT_FUNCTION_LIST_DIR}/fortran_plugin.F90.in
-        ${CMAKE_CURRENT_BINARY_DIR}/fortran_plugin.F90 @ONLY
+        ${CMAKE_CURRENT_BINARY_DIR}/fortran_plugin${PREC_SUFFIX}.F90 @ONLY
     )
 
     # set source files to be included 
     set(INTERFACE_PLUGIN_SOURCES
-        ${CMAKE_CURRENT_BINARY_DIR}/fortran_plugin.h
-        ${CMAKE_CURRENT_BINARY_DIR}/fortran_plugin.cc
-        ${CMAKE_CURRENT_BINARY_DIR}/fortran_plugin.F90
-        ${GENERATED_USER_SOURCE_FILE}
+        ${CMAKE_CURRENT_BINARY_DIR}/fortran_plugin${PREC_SUFFIX}.h
+        ${CMAKE_CURRENT_BINARY_DIR}/fortran_plugin${PREC_SUFFIX}.cc
+        ${CMAKE_CURRENT_BINARY_DIR}/fortran_plugin${PREC_SUFFIX}.F90
+        ${CONFIGURED_PLUGIN_FILENAME}
         PARENT_SCOPE
     )
 


### PR DESCRIPTION
This is to make the cmake function "plume_plugin_interface" create separate interface files for fortran plugins that can be built as SP and DP in the same build