### PR TITLE
PLUME-37: Add tags to plugin run to identify the calling model

### DIFF
--- a/examples/example1.c
+++ b/examples/example1.c
@@ -58,7 +58,7 @@ int main(int argc, char** argv){
 
     // Run all plugins for several iterations
     for(int i=0; i<10; i++) {
-      plume_manager_run(mgr_handle);
+      plume_manager_run(mgr_handle, NULL);
 
       // e.g. update parameters..
       param_i++;

--- a/src/nwp_emulator/nwp_emulator.cc
+++ b/src/nwp_emulator/nwp_emulator.cc
@@ -140,6 +140,7 @@ bool NWPEmulator::setupPlume(NWPDataProvider& dataProvider) {
     offers.offerInt("NSTEP", "always", "Simulation Step");
     offers.offerDouble("TSTEP", "always", "Simulation Time Step");
     offers.offerInt("NFLEVG", "always", "Number of vertical levels");
+    offers.offerInt("WSTEP", "always", "Wave simulation time");
     auto fields = dataProvider.getModelFieldSet();
     for (const auto& field: fields) {
         offers.offerAtlasField(field.name(), "on-request", field.name());
@@ -148,6 +149,7 @@ bool NWPEmulator::setupPlume(NWPDataProvider& dataProvider) {
     plumeData_.createInt("NSTEP", 0);  /// Initialise parameters
     plumeData_.createDouble("TSTEP", 900.0);
     plumeData_.createInt("NFLEVG", dataProvider.getLevels());
+    plumeData_.createInt("WSTEP", 0);
     for (auto& field: fields) {
         if (plume::Manager::isParamRequested(field.name())) {
             plumeData_.provideAtlasFieldShared(field.name(), field.get());
@@ -161,6 +163,7 @@ bool NWPEmulator::setupPlume(NWPDataProvider& dataProvider) {
 void NWPEmulator::runPlume(int step) {
     plume::Manager::run();
     plumeData_.updateInt("NSTEP", step);
+    plumeData_.updateInt("WSTEP", std::ceil(step * plumeData_.getDouble("TSTEP")));
 }
 
 int main(int argc, char** argv) {

--- a/src/plume/Manager.cc
+++ b/src/plume/Manager.cc
@@ -202,9 +202,15 @@ void Manager::feedPlugins(const data::ModelData& data) {
 
 
 // Run all active plugincores
-void Manager::run() {
-    for (auto& pluginHandler : PluginRegistry::instance().getActivePlugins()) {
-        pluginHandler.run();
+void Manager::run(int* caller) {
+    if (caller != nullptr) {
+        for (auto& pluginHandler : PluginRegistry::instance().getActivePlugins()) {
+            pluginHandler.run(*caller);
+        }
+    } else {
+        for (auto& pluginHandler : PluginRegistry::instance().getActivePlugins()) {
+            pluginHandler.run();
+        }
     }
 };
 

--- a/src/plume/Manager.h
+++ b/src/plume/Manager.h
@@ -62,8 +62,10 @@ public:
     /**
      * @brief run all active plugins
      * 
+     * @param caller Identifies the calling model. Defaults to nullptr, so the caller can be passed or not depending
+     *        on how the simulation and plugins are configured.
      */
-    static void run();
+    static void run(int* caller = nullptr);
 
     /**
      * @brief teardown all active plugins

--- a/src/plume/PluginCore.cc
+++ b/src/plume/PluginCore.cc
@@ -14,6 +14,7 @@
 
 namespace plume {
 
+
 PluginCore::PluginCore(const eckit::Configuration& config) {}
 
 PluginCore::~PluginCore() {}
@@ -30,6 +31,10 @@ void PluginCore::grabData(const data::ModelData& data) {
 
 data::ModelData& PluginCore::modelData() {
     return modelData_;
+}
+
+void PluginCore::run(int caller) {
+    run();
 }
 
 

--- a/src/plume/PluginCore.h
+++ b/src/plume/PluginCore.h
@@ -22,6 +22,7 @@
 
 namespace plume {
 
+
 /**
  * @brief A plugincore that contains calculations/algorithms
  * to perform on model data. It is implemented inside a plugin
@@ -87,6 +88,17 @@ public:
      * 
      */
     virtual void run() = 0;
+
+    /**
+     * @brief Run with information about the caller.
+     * 
+     * By default this method calls the base run method without caller.
+     * The caller is not decoded in Plume, the responsibility of correctly associating a caller number to a model
+     * lies with the individual plugin configurations.
+     * 
+     * @param caller The model that called the run represented by an int.
+     */
+    virtual void run(int caller);
 
 protected:
 

--- a/src/plume/PluginHandler.cc
+++ b/src/plume/PluginHandler.cc
@@ -52,6 +52,11 @@ void PluginHandler::run() {
 }
 
 
+void PluginHandler::run(int caller) {
+    plugincorePtr_->run(caller);
+}
+
+
 void PluginHandler::teardown() {
     plugincorePtr_->teardown();
 }

--- a/src/plume/PluginHandler.h
+++ b/src/plume/PluginHandler.h
@@ -81,6 +81,13 @@ public:
     void run();
 
     /**
+     * @brief run the plugincore with a caller tag
+     * 
+     * @param caller The model that called the run
+     */
+    void run(int caller);
+
+    /**
      * @brief teardown the plugincore
      * 
      */

--- a/src/plume/api/plume.cc
+++ b/src/plume/api/plume.cc
@@ -328,12 +328,12 @@ int plume_manager_is_plugin_activated(plume_manager_handle_t* h, const char* nam
     });
 }
 
-int plume_manager_run(plume_manager_handle_t* h) {
-    return wrapApiFunction([h] {
+int plume_manager_run(plume_manager_handle_t* h, int* caller) {
+    return wrapApiFunction([h, caller] {
         ASSERT(h);
         ASSERT((h)->impl_);
 
-        h->impl_->run();
+        h->impl_->run(caller);
     });
 }
 

--- a/src/plume/api/plume.h
+++ b/src/plume/api/plume.h
@@ -205,9 +205,10 @@ int plume_manager_is_plugin_activated(plume_manager_handle_t* h, const char* nam
  * @brief Run all plugins
  *
  * @param h Handle
+ * @param caller Tag identifying the model calling the run
  * @return Error code
  */
-int plume_manager_run(plume_manager_handle_t* h);
+int plume_manager_run(plume_manager_handle_t* h, int* caller);
 
 /**
  * @brief Teardown plugins

--- a/src/plume/api/plume_manager.F90
+++ b/src/plume/api/plume_manager.F90
@@ -118,10 +118,11 @@ function plume_manager_feed_plugins_interf(handle_impl, fdata) result(err) &
   integer(c_int) :: err
 end function
 
-function plume_manager_run_interf(handle_impl) result(err) &
+function plume_manager_run_interf(handle_impl, run_tag) result(err) &
     & bind(C,name="plume_manager_run")
     use iso_c_binding, only: c_int, c_ptr
     type(c_ptr), intent(in), value :: handle_impl
+    integer(c_int), intent(in), optional :: run_tag
     integer(c_int) :: err
 end function
 
@@ -181,10 +182,15 @@ function plume_manager_feed_plugins(handle, fdata) result(err)
   err = plume_manager_feed_plugins_interf(handle%impl, fdata%impl)
 end function
 
-function plume_manager_run(handle) result(err)
+function plume_manager_run(handle, run_tag) result(err)
     class(plume_manager), intent(inout) :: handle
+    integer, intent(in), optional :: run_tag
     integer :: err
-    err = plume_manager_run_interf(handle%impl)
+    if (present(run_tag)) then
+        err = plume_manager_run_interf(handle%impl, run_tag)
+    else
+        err = plume_manager_run_interf(handle%impl)
+    endif
 end function
 
 ! TODO: this really need to be checked!! not testing for errors, but returns a char*

--- a/tests/api/test_manager_api.cc
+++ b/tests/api/test_manager_api.cc
@@ -132,7 +132,7 @@ CASE("test_manager_api") {
 
     // run the plugin for 2 iterations
     for (int i = 0; i < 2; ++i) {
-        EXPECT_PLUME_CODE_SUCCESS( plume_manager_run(mgr_handle));
+        EXPECT_PLUME_CODE_SUCCESS( plume_manager_run(mgr_handle, NULL));
     }
 
     // finalise plume


### PR DESCRIPTION
This PR introduces a change in the run api of Plume so integer tags can be passed as run arguments. This integer can then be used by plugins to determine if they should run or not, or if so which part should run. It is kept as simple as an int for now to keep any actual model knowledge out of Plume, but it may be refined into a more complete tag api if needed in the future.
The plugins can run as before, or use the tag if one is provided, ideally no model knowledge will be hardcoded in plugin, and the mapping int - model will come from the configuration. (This is open for discussion)
 