### PR TITLE
PLUME-14: Build the emulator in both SP and DP

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,14 +48,30 @@ ecbuild_info("FCKIT_FOUND ${fckit_FOUND}")
 ecbuild_info("FCKIT_LIBRARIES ${FCKIT_LIBRARIES}")
 ecbuild_info("FCKIT_INCLUDE_DIRS ${FCKIT_INCLUDE_DIRS}")
 
-############## PRECISION
+############## NWP EMULATOR PRECISION
 ecbuild_add_option( FEATURE NWP_EMULATOR_SINGLE_PRECISION
-                    DESCRIPTION "Single precision Atlas fields"
-                    DEFAULT OFF )
+                    DESCRIPTION
+                    "Compile nwp emulator for single precision fields"
+                    DEFAULT OFF)
 
-if( HAVE_NWP_EMULATOR_SINGLE_PRECISION ) 
-  list(APPEND NWP_EMULATOR_DEFINITIONS WITH_NWP_EMULATOR_SINGLE_PRECISION )
+ecbuild_add_option( FEATURE NWP_EMULATOR_DOUBLE_PRECISION
+                    DESCRIPTION
+                    "Compile nwp emulator for double precision fields"
+                    DEFAULT ON)
+
+set( HAVE_NWP_EMULATOR_sp 0)
+set( HAVE_NWP_EMULATOR_dp 0)
+
+if (HAVE_SINGLE_PRECISION OR HAVE_NWP_EMULATOR_SINGLE_PRECISION)
+  set( NWP_EMULATOR_DEFINITIONS_sp WITH_NWP_EMULATOR_SINGLE_PRECISION )
+  set( HAVE_NWP_EMULATOR_sp 1)
 endif()
+
+if (HAVE_NWP_EMULATOR_DOUBLE_PRECISION)
+  set( NWP_EMULATOR_DEFINITIONS_dp WITH_NWP_EMULATOR_DOUBLE_PRECISION )
+  set( HAVE_NWP_EMULATOR_dp 1)
+endif()
+############################################################################################
 
 add_subdirectory( src )
 add_subdirectory( tests )

--- a/src/nwp_emulator/CMakeLists.txt
+++ b/src/nwp_emulator/CMakeLists.txt
@@ -6,38 +6,48 @@
 # In applying this licence, ECMWF does not waive the privileges and immunities
 # granted to it by virtue of its status as an intergovernmental organisation nor
 # does it submit to any jurisdiction.
-ecbuild_add_library(
-    TARGET plume_nwp_emulator
-    INSTALL_HEADERS LISTED
-    HEADER_DESTINATION
-        ${INSTALL_INCLUDE_DIR}/nwp_emulator
-    SOURCES
-        data_reader.h
-        grib_file_reader.h
-        config_reader.h
-        nwp_definitions.h
-        nwp_data_provider.h
-        nwp_data_provider.cc
-        grib_file_reader.cc
-        config_reader.cc
-        config_reader_funcs.cc
-    PUBLIC_INCLUDES
-       $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}/src>
-       $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/src>
-    PRIVATE_INCLUDES
-        "${MPI_INCLUDE_DIRS}"
-    DEFINITIONS
-        ${NWP_EMULATOR_DEFINITIONS}
-    PUBLIC_LIBS
-        plume_plugin
-        plume_plugin_manager
-        eccodes
-        eckit
-)
+foreach(prec sp dp)
+    if (HAVE_NWP_EMULATOR_${prec})
+        set(NWP_EMULATOR_LIB_NAME "plume_nwp_emulator_${prec}")
+        message(STATUS "Building ${NWP_EMULATOR_LIB_NAME} and definitions: ${NWP_EMULATOR_DEFINITIONS_${prec}}")
 
-ecbuild_add_executable( TARGET nwp_emulator_run.x
-  SOURCES
-    nwp_emulator.cc
-  LIBS
-    plume_nwp_emulator
-)
+        ecbuild_add_library(
+            TARGET ${NWP_EMULATOR_LIB_NAME}
+            INSTALL_HEADERS LISTED
+            HEADER_DESTINATION
+                ${INSTALL_INCLUDE_DIR}/nwp_emulator_${prec}
+            SOURCES
+                data_reader.h
+                grib_file_reader.h
+                config_reader.h
+                nwp_definitions.h
+                nwp_data_provider.h
+                nwp_data_provider.cc
+                grib_file_reader.cc
+                config_reader.cc
+                config_reader_funcs.cc
+            PUBLIC_INCLUDES
+                $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}/src>
+                $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/src>
+            PRIVATE_INCLUDES
+                "${MPI_INCLUDE_DIRS}"
+            DEFINITIONS
+                ${NWP_EMULATOR_DEFINITIONS_${prec}}
+            PUBLIC_LIBS
+                plume_plugin
+                plume_plugin_manager
+                eccodes
+                eckit
+        )
+
+        ecbuild_add_executable(
+            TARGET nwp_emulator_run_${prec}.x
+            SOURCES
+                nwp_emulator.cc
+            LIBS
+                ${NWP_EMULATOR_LIB_NAME}
+        )
+    endif()
+endforeach()
+
+

--- a/tests/nwp_emulator/CMakeLists.txt
+++ b/tests/nwp_emulator/CMakeLists.txt
@@ -26,38 +26,44 @@ ecbuild_get_test_multidata(
     NOCHECK
 )
 
-ecbuild_add_test(
-    TARGET      plume_test_nwp_grib
-    SOURCES     test_grib_reader.cc
-    LIBS        plume_nwp_emulator
-    ENVIRONMENT TEST_DATA_DIR=${test_nwp_emulator_files_dir}
-    MPI         3
-    CONDITION   eckit_HAVE_MPI
-    TEST_DEPENDS test_nwp_emulator_files
-)
+foreach(prec sp dp)
+    if (HAVE_NWP_EMULATOR_${prec})
+        ecbuild_add_test(
+            TARGET      plume_test_nwp_grib_${prec}
+            SOURCES     test_grib_reader.cc
+            LIBS        plume_nwp_emulator_${prec}
+            DEFINITIONS ${NWP_EMULATOR_DEFINITIONS_${prec}}
+            ENVIRONMENT TEST_DATA_DIR=${test_nwp_emulator_files_dir}
+            MPI         3
+            CONDITION   eckit_HAVE_MPI
+            TEST_DEPENDS test_nwp_emulator_files
+        )
 
-ecbuild_add_test(
-    TARGET      plume_test_nwp_config
-    SOURCES     test_config_reader.cc
-    LIBS        plume_nwp_emulator
-    ENVIRONMENT TEST_DATA_DIR=${CMAKE_CURRENT_SOURCE_DIR}/data/
-    MPI         3
-    CONDITION   eckit_HAVE_MPI
-)
+        ecbuild_add_test(
+            TARGET      plume_test_nwp_config_${prec}
+            SOURCES     test_config_reader.cc
+            LIBS        plume_nwp_emulator_${prec}
+            DEFINITIONS ${NWP_EMULATOR_DEFINITIONS_${prec}}
+            ENVIRONMENT TEST_DATA_DIR=${CMAKE_CURRENT_SOURCE_DIR}/data/
+            MPI         3
+            CONDITION   eckit_HAVE_MPI
+        )
 
-ecbuild_add_library(
-    TARGET nwp_emulator_test_plugin
-    SOURCES 
-        nwp_emulator_plugin.h
-        nwp_emulator_plugin.cc
-    PRIVATE_LIBS
-        plume_plugin
-)
+        ecbuild_add_library(
+            TARGET nwp_emulator_test_plugin_${prec}
+            SOURCES 
+                nwp_emulator_plugin.h
+                nwp_emulator_plugin.cc
+            PRIVATE_LIBS
+                plume_plugin
+        )
 
-ecbuild_add_test(
-    TARGET  plume_test_nwp_tool
-    LIBS simple_plugin nwp_emulator_test_plugin
-    COMMAND nwp_emulator_run.x
-    ARGS --config-src=${CMAKE_CURRENT_SOURCE_DIR}/data/valid_config.yml
-         --plume-cfg=${CMAKE_CURRENT_SOURCE_DIR}/data/plume_config.yml
-)
+        ecbuild_add_test(
+            TARGET  plume_test_nwp_tool_${prec}
+            LIBS simple_plugin nwp_emulator_test_plugin_${prec}
+            COMMAND nwp_emulator_run_${prec}.x
+            ARGS --config-src=${CMAKE_CURRENT_SOURCE_DIR}/data/valid_config.yml
+                --plume-cfg=${CMAKE_CURRENT_SOURCE_DIR}/data/plume_config_${prec}.yml
+        )
+    endif()
+endforeach()

--- a/tests/nwp_emulator/data/plume_config_dp.yml
+++ b/tests/nwp_emulator/data/plume_config_dp.yml
@@ -3,5 +3,5 @@ plugins:
     lib: "simple_plugin"
     core-config: {}
   - name: "NWPEmulatorPlugin"
-    lib: "nwp_emulator_test_plugin"
+    lib: "nwp_emulator_test_plugin_dp"
     core-config: {}

--- a/tests/nwp_emulator/data/plume_config_sp.yml
+++ b/tests/nwp_emulator/data/plume_config_sp.yml
@@ -1,0 +1,7 @@
+plugins:
+  - name: "SimplePlugin"
+    lib: "simple_plugin"
+    core-config: {}
+  - name: "NWPEmulatorPlugin"
+    lib: "nwp_emulator_test_plugin_sp"
+    core-config: {}


### PR DESCRIPTION
This PR introduces the possibility to build the emulator both for single and double precision (or either or).
The plugins can therefore use it in both precisions, for quick testing or building test suites, e.g., ee plugin.
 