### PR TITLE
PLUME-49: Build the NWP emulator optionally

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,7 +20,6 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 ### dependencies and options
 ecbuild_find_package( NAME eckit  VERSION  1.28.5 REQUIRED )
 ecbuild_find_package( NAME atlas )
-ecbuild_find_package( NAME eccodes )
 
 ecbuild_add_option( FEATURE BUILD_TOOLS
                     DEFAULT ON
@@ -48,28 +47,35 @@ ecbuild_info("FCKIT_FOUND ${fckit_FOUND}")
 ecbuild_info("FCKIT_LIBRARIES ${FCKIT_LIBRARIES}")
 ecbuild_info("FCKIT_INCLUDE_DIRS ${FCKIT_INCLUDE_DIRS}")
 
-############## NWP EMULATOR PRECISION
-ecbuild_add_option( FEATURE NWP_EMULATOR_SINGLE_PRECISION
-                    DESCRIPTION
-                    "Compile nwp emulator for single precision fields"
-                    DEFAULT OFF)
+############## NWP EMULATOR PRECISION & ENABLING
+ecbuild_add_option( FEATURE NWP_EMULATOR
+                    DEFAULT ON
+                    DESCRIPTION "Compile the NWP emulator"
+                    REQUIRED_PACKAGES eccodes )
 
-ecbuild_add_option( FEATURE NWP_EMULATOR_DOUBLE_PRECISION
-                    DESCRIPTION
-                    "Compile nwp emulator for double precision fields"
-                    DEFAULT ON)
+if (HAVE_NWP_EMULATOR)
+  ecbuild_add_option( FEATURE NWP_EMULATOR_SINGLE_PRECISION
+                      DESCRIPTION
+                      "Compile nwp emulator for single precision fields"
+                      DEFAULT OFF)
 
-set( HAVE_NWP_EMULATOR_sp 0)
-set( HAVE_NWP_EMULATOR_dp 0)
+  ecbuild_add_option( FEATURE NWP_EMULATOR_DOUBLE_PRECISION
+                      DESCRIPTION
+                      "Compile nwp emulator for double precision fields"
+                      DEFAULT ON)
 
-if (HAVE_SINGLE_PRECISION OR HAVE_NWP_EMULATOR_SINGLE_PRECISION)
-  set( NWP_EMULATOR_DEFINITIONS_sp WITH_NWP_EMULATOR_SINGLE_PRECISION )
-  set( HAVE_NWP_EMULATOR_sp 1)
-endif()
+  set( HAVE_NWP_EMULATOR_sp 0)
+  set( HAVE_NWP_EMULATOR_dp 0)
 
-if (HAVE_NWP_EMULATOR_DOUBLE_PRECISION)
-  set( NWP_EMULATOR_DEFINITIONS_dp WITH_NWP_EMULATOR_DOUBLE_PRECISION )
-  set( HAVE_NWP_EMULATOR_dp 1)
+  if (HAVE_SINGLE_PRECISION OR HAVE_NWP_EMULATOR_SINGLE_PRECISION)
+    set( NWP_EMULATOR_DEFINITIONS_sp WITH_NWP_EMULATOR_SINGLE_PRECISION )
+    set( HAVE_NWP_EMULATOR_sp 1)
+  endif()
+
+  if (HAVE_NWP_EMULATOR_DOUBLE_PRECISION)
+    set( NWP_EMULATOR_DEFINITIONS_dp WITH_NWP_EMULATOR_DOUBLE_PRECISION )
+    set( HAVE_NWP_EMULATOR_dp 1)
+  endif()
 endif()
 ############################################################################################
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -9,4 +9,6 @@
 
 add_subdirectory(plume)
 
-add_subdirectory(nwp_emulator)
+if (HAVE_NWP_EMULATOR)
+    add_subdirectory(nwp_emulator)
+endif()

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -13,4 +13,7 @@ endif()
 
 add_subdirectory(core)
 add_subdirectory(api)
-add_subdirectory(nwp_emulator)
+
+if (HAVE_NWP_EMULATOR)
+  add_subdirectory(nwp_emulator)
+endif()


### PR DESCRIPTION
### Description

This PR allows to build the emulator as an option, as it is typically not used in builds that contain a model source.
It allows to remove the dependency on eccodes, and introduces it only if the emulator is enabled.

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 