### PR TITLE
PLUME-37: Add param updated state tracking to model data

### DIFF
--- a/src/nwp_emulator/nwp_emulator.cc
+++ b/src/nwp_emulator/nwp_emulator.cc
@@ -136,11 +136,16 @@ int NWPEmulator::execute(const Args& args) {
 bool NWPEmulator::setupPlume(NWPDataProvider& dataProvider) {
     plume::Manager::configure(eckit::YAMLConfiguration(eckit::PathName(plumeConfigPath_)));
 
+    // Set all the non-const params updated flags to true so it doesn't have to be done at run step
+    std::vector<std::string> updatingParams;
+
     plume::Protocol offers;  /// Define data offered by Plume
     offers.offerInt("NSTEP", "always", "Simulation Step");
+    updatingParams.push_back("NSTEP");
     offers.offerDouble("TSTEP", "always", "Simulation Time Step");
     offers.offerInt("NFLEVG", "always", "Number of vertical levels");
     offers.offerInt("WSTEP", "always", "Wave simulation time");
+    updatingParams.push_back("WSTEP");
     auto fields = dataProvider.getModelFieldSet();
     for (const auto& field: fields) {
         offers.offerAtlasField(field.name(), "on-request", field.name());
@@ -153,10 +158,13 @@ bool NWPEmulator::setupPlume(NWPDataProvider& dataProvider) {
     for (auto& field: fields) {
         if (plume::Manager::isParamRequested(field.name())) {
             plumeData_.provideAtlasFieldShared(field.name(), field.get());
+            updatingParams.push_back(field.name());
         }
     }
 
     plume::Manager::feedPlugins(plumeData_);
+
+    plumeData_.setUpdated(updatingParams);
     return true;
 }
 

--- a/src/plume/api/plume.cc
+++ b/src/plume/api/plume.cc
@@ -512,6 +512,14 @@ int plume_data_print(plume_data_handle_t* h) {
     return wrapApiFunction([h] { h->impl_->print(); });
 }
 
+int plume_data_set_updated(plume_data_handle_t* h, const int count, const char** names) {
+    std::vector<std::string> params;
+    for (int i = 0; i < count; ++i) {
+        params.push_back(names[i]);
+    }
+    return wrapApiFunction([h, params] {h->impl_->setUpdated(params); });
+}
+
 // --------------------------------------------------------------------------------------
 
 

--- a/src/plume/api/plume.h
+++ b/src/plume/api/plume.h
@@ -447,6 +447,16 @@ int plume_data_get_double(plume_data_handle_t* h, const char* name, double* val)
  */
 int plume_data_print(plume_data_handle_t* h);
 
+/**
+ * @brief Set params updated flag
+ *
+ * @param h Handle
+ * @param count Number of parameters updated
+ * @param names The names of the updated parameters
+ * @return Error code
+ */
+int plume_data_set_updated(plume_data_handle_t* h, const int count, const char** names);
+
 
 #if defined(__cplusplus)
 }  // extern "C"

--- a/src/plume/api/plume_data.F90
+++ b/src/plume/api/plume_data.F90
@@ -44,6 +44,8 @@ contains
     procedure :: get_double                 => plume_data_get_double
     procedure :: get_shared_atlas_field     => plume_data_get_shared_atlas_field
 
+    procedure :: set_updated                => plume_data_set_updated
+
     procedure :: print => plume_data_print
     procedure :: finalise => plume_data_delete_handle
 
@@ -76,6 +78,15 @@ function plume_data_print_interf( handle_impl ) result(err) &
     integer(c_int) :: err
 end function
 
+
+function plume_data_set_updated_interf( handle_impl, count, names ) result(err) &
+  & bind(C,name="plume_data_set_updated")
+  use iso_c_binding, only: c_int, c_ptr
+  type(c_ptr), intent(in), value :: handle_impl
+  integer(c_int), intent(in), value :: count
+  type(c_ptr), dimension(*), intent(in) :: names
+  integer(c_int) :: err
+end function
 
 
 ! ------------- Data "creators"
@@ -494,6 +505,21 @@ function plume_data_print( handle ) result(err)
   class(plume_data), intent(inout) :: handle
   integer :: err
   err = plume_data_print_interf(handle%impl)
+end function
+
+function plume_data_set_updated( handle, names ) result(err)
+  use iso_c_binding, only: c_char, c_int, c_loc
+  class(plume_data), intent(inout) :: handle
+  character(kind=c_char,len=:), allocatable, target, intent(in) :: names(:)
+  type(c_ptr), allocatable :: c_param_names(:)
+  integer :: err, i, count
+
+  count = size(names)
+  allocate(c_param_names(count))
+  do i = 1, count
+    c_param_names(i) = c_loc(names(i))
+  end do
+  err = plume_data_set_updated_interf(handle%impl, count, c_param_names)
 end function
 
 

--- a/src/plume/data/ModelData.cc
+++ b/src/plume/data/ModelData.cc
@@ -208,6 +208,29 @@ bool ModelData::hasParameter(const std::string& name, const ParameterType& type)
 }
 
 
+bool ModelData::isUpdated(const std::string& name) const {
+    ASSERT_MSG(valueMap_.find(name) != valueMap_.end(), "Element not found in model data: " + name );
+    return valueMap_.at(name)->isUpdated();
+}
+
+
+void ModelData::setUpdated(const std::vector<std::string>& params) {
+    clearUpdated();
+    for (const auto& name : params) {
+        ASSERT_MSG( valueMap_.find(name) != valueMap_.end(),
+                    "Element not found in model data: " + name );
+        valueMap_.at(name)->setUpdated(true);
+    }    
+}
+
+
+void ModelData::clearUpdated() {
+    for (const auto& [param, value] : valueMap_) {
+        value->setUpdated(false);
+    }
+}
+
+
 void ModelData::print() const {
     eckit::Log::info() << "*** Parameters: " << std::endl;
     for (auto k : valueMap_) {

--- a/src/plume/data/ModelData.h
+++ b/src/plume/data/ModelData.h
@@ -82,6 +82,11 @@ public:
     bool hasParameter(const std::string& name) const ;
     bool hasParameter(const std::string& name, const ParameterType& type) const ;
 
+    // Manage parameters updated state
+    bool isUpdated(const std::string& name) const; // for plugins to query
+    void setUpdated(const std::vector<std::string>& params); // for data providers
+    void clearUpdated(); // for data providers or Plume manager to clear after run
+
     // list available parameters of a certain type
     std::vector<std::string> listAvailableParameters(std::string type_string) const ;
 

--- a/src/plume/data/Parameter.h
+++ b/src/plume/data/Parameter.h
@@ -138,14 +138,17 @@ public:
 
     ParameterValue(void* valuePtr, ParameterType type) : 
         contentPtr_{valuePtr},
-        type_{type} {}
+        type_{type},
+        isUpdated_{false} {}
         
-    virtual ~ParameterValue(){};
+    virtual ~ParameterValue() = default;
     ParameterValue(const ParameterValue& other)  = delete;
     ParameterValue& operator=(const ParameterValue& other) = delete;
 
     virtual std::string toString() const {return ParameterTypeConverter::toString(type_);}
     virtual ParameterType type() const {return type_;}
+    virtual bool isUpdated() const {return isUpdated_;}
+    virtual void setUpdated(bool updated) {isUpdated_ = updated;}
 
     // owns the underlying data?
     virtual bool owns() const = 0;
@@ -165,6 +168,7 @@ public:
 protected:
     ParameterType type_;
     void* contentPtr_;
+    bool isUpdated_;
 
 };
 

--- a/tests/api/test_data_api.F90
+++ b/tests/api/test_data_api.F90
@@ -41,6 +41,8 @@ integer :: param_cc_i_check = -999
 real(c_float) :: param_cc_f_check = -999.0
 real(c_double) :: param_cc_d_check = -999.0
 
+! check updated parameter array
+character(len=:,kind=c_char), allocatable, target :: names(:)
 
 call atlas_library%initialise()
 call plume_check(plume_initialise())
@@ -93,6 +95,15 @@ FCTEST_CHECK(param_cc_d_check == -2.2)
 call plume_check(data%update_int("CC_I", 777) )
 call plume_check(data%update_float("CC_F", real(888.8,kind=c_float)) )
 call plume_check(data%update_double("CC_D", real(999.9,kind=c_double)) )
+
+! set the updated params flag to true
+! len is 5 because it needs room for the 4 chars and the null terminator
+allocate(character(len=5) :: names(3))
+names(1) = "CC_I"//C_NULL_CHAR
+names(2) = "CC_F"//C_NULL_CHAR
+names(3) = "CC_D"//C_NULL_CHAR
+call plume_check(data%set_updated(names))
+deallocate(names)
 
 ! check updated parameters
 call plume_check(data%get_int("CC_I", param_cc_i_check))

--- a/tests/api/test_data_api.cc
+++ b/tests/api/test_data_api.cc
@@ -91,6 +91,9 @@ CASE("test_data_api") {
     EXPECT_PLUME_CODE_SUCCESS( plume_data_update_float(data_handle, "CC_F", 888.8f) );
     EXPECT_PLUME_CODE_SUCCESS( plume_data_update_double(data_handle, "CC_D", 999.9) );
 
+    const char* updated_params[] = { "CC_I", "CC_F", "CC_D" };
+    EXPECT_PLUME_CODE_SUCCESS( plume_data_set_updated(data_handle, 3, updated_params));
+
     // check updated parameters
     EXPECT_PLUME_CODE_SUCCESS( plume_data_get_int(data_handle, "CC_I", &param_cc_i_check) );
     EXPECT_EQUAL(param_cc_i_check, 777);

--- a/tests/core/test_model_data.cc
+++ b/tests/core/test_model_data.cc
@@ -80,6 +80,38 @@ CASE("test model data - type checks 2") {
     EXPECT_THROWS(data.getAtlasFieldShared("not-existant-field"));
 }
 
+CASE("test model data - update status") {
+
+    plume::data::ModelData data;
+
+    int paramA = 1;
+    int paramB = 2;
+    data.provideInt("paramA", &paramA);
+    data.provideInt("paramB", &paramB);
+
+    EXPECT_NOT(data.isUpdated("paramA")); // Params are initialised *not* updated
+
+    data.setUpdated({"paramA"});
+
+    EXPECT(data.isUpdated("paramA")); // Only request param is set as updated
+    EXPECT_NOT(data.isUpdated("paramB"));
+
+    data.setUpdated({"paramB"});
+
+    EXPECT_NOT(data.isUpdated("paramA")); // setting another param as updated resets other params status to not updated
+    EXPECT(data.isUpdated("paramB"));
+
+    data.clearUpdated();
+
+    EXPECT_NOT(data.isUpdated("paramA")); // clearing resets all params updated status
+    EXPECT_NOT(data.isUpdated("paramB"));
+
+    data.setUpdated({"paramA", "paramB"});
+
+    EXPECT(data.isUpdated("paramA")); // all requested params are set as updated
+    EXPECT(data.isUpdated("paramB"));
+}
+
 //----------------------------------------------------------------------------------------------------------------------
 
 }  // namespace plume::test


### PR DESCRIPTION
### Description

Opening this PR as draft to receive initial feedback but the API hasn't been tested with IFS yet.
This PR adds utility methods to the Plume model data to keep track of the update status of each parameter. This status can be queried by plugins to know whether the params they use have been updated since the last time they ran, helping to decide whether or what parts to run.

This development is meant instead of the alternative in [this PR](https://github.com/ecmwf/plume/pull/16).

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 