### PR TITLE
Adjust the test data path for Nexus migration

### DIFF
--- a/tests/nwp_emulator/CMakeLists.txt
+++ b/tests/nwp_emulator/CMakeLists.txt
@@ -7,7 +7,6 @@
 # granted to it by virtue of its status as an intergovernmental organisation nor
 # does it submit to any jurisdiction.
 # Test files repository on Nexus
-set(ECBUILD_DOWNLOAD_BASE_URL https://get.ecmwf.int/repository/plume-test-data)
 
 set(test_nwp_emulator_files_dir ${CMAKE_BINARY_DIR}/tests/nwp_emulator/data)
 add_custom_target(
@@ -20,7 +19,7 @@ ecbuild_get_test_multidata(
         model_data_1.grib
         model_data_2.grib
     DIRNAME
-        nwp_emulator
+        plume/test-data/nwp_emulator
     DIRLOCAL
         ${test_nwp_emulator_files_dir}
     NOCHECK


### PR DESCRIPTION
### Description

Adjust the test data path for Nexus migration. Instead of using https://get.ecmwf.int/repository/test-data/*project*/, the project will now access the data at https://sites.ecmwf.int/repository/*project*/test-data/.

This change also implies the use of the latest ecbuild, with the necessary adjustments to ecbuild_get_test_data/multidata functions.

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 