### PR TITLE
ci: migrate ecmwf-actions references to ecmwf

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
   downstream-ci:
     name: downstream-ci
     if: ${{ !github.event.pull_request.head.repo.fork && github.event.action != 'labeled' || github.event.label.name == 'approved-for-ci' }}
-    uses: ecmwf-actions/downstream-ci/.github/workflows/downstream-ci.yml@main
+    uses: ecmwf/downstream-ci/.github/workflows/downstream-ci.yml@main
     with:
       plume: ecmwf/plume@${{ github.event.pull_request.head.sha || github.sha }}
       codecov_upload: true
@@ -40,7 +40,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Dispatch private downstream CI
-        uses: ecmwf-actions/dispatch-private-downstream-ci@v1
+        uses: ecmwf/dispatch-private-downstream-ci@v1
         with:
           token: ${{ secrets.GH_REPO_READ_TOKEN }}
           owner: ecmwf-actions
@@ -52,7 +52,7 @@ jobs:
   downstream-ci-hpc:
     name: downstream-ci-hpc
     if: ${{ !github.event.pull_request.head.repo.fork && github.event.action != 'labeled' || github.event.label.name == 'approved-for-ci' }}
-    uses: ecmwf-actions/downstream-ci/.github/workflows/downstream-ci-hpc.yml@main
+    uses: ecmwf/downstream-ci/.github/workflows/downstream-ci-hpc.yml@main
     with:
       plume: ecmwf/plume@${{ github.event.pull_request.head.sha || github.sha }}
     secrets: inherit
@@ -67,7 +67,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Dispatch private downstream CI
-        uses: ecmwf-actions/dispatch-private-downstream-ci@v1
+        uses: ecmwf/dispatch-private-downstream-ci@v1
         with:
           token: ${{ secrets.GH_REPO_READ_TOKEN }}
           owner: ecmwf-actions
@@ -85,7 +85,7 @@ jobs:
     if: always() && ${{ !github.event.pull_request.head.repo.fork && github.event.action != 'labeled' || github.event.label.name == 'approved-for-ci' }}
     steps:
       - name: Trigger Teams notification
-        uses: ecmwf-actions/notify-teams@v1
+        uses: ecmwf/notify-teams@v1
         with:
           incoming_webhook: ${{ secrets.MS_TEAMS_INCOMING_WEBHOOK }}
           needs_context: ${{ toJSON(needs) }}

--- a/.github/workflows/label-public-pr.yml
+++ b/.github/workflows/label-public-pr.yml
@@ -7,4 +7,4 @@ on:
 
 jobs:
   label:
-    uses: ecmwf-actions/reusable-workflows/.github/workflows/label-pr.yml@v2
+    uses: ecmwf/reusable-workflows/.github/workflows/label-pr.yml@v2

--- a/.github/workflows/notify-new-issue.yml
+++ b/.github/workflows/notify-new-issue.yml
@@ -10,6 +10,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Notify new issue
-      uses: ecmwf-actions/notify-teams-issue@v1
+      uses: ecmwf/notify-teams-issue@v1
       with:
         incoming_webhook: ${{ secrets.MS_TEAMS_INCOMING_WEBHOOK }}

--- a/.github/workflows/notify-new-pr.yml
+++ b/.github/workflows/notify-new-pr.yml
@@ -10,6 +10,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Notify new PR
-      uses: ecmwf-actions/notify-teams-pr@v1
+      uses: ecmwf/notify-teams-pr@v1
       with:
         incoming_webhook: ${{ secrets.MS_TEAMS_INCOMING_WEBHOOK }}


### PR DESCRIPTION
## Summary
The `ecmwf-actions` GitHub organization has been merged into `ecmwf`.
This PR updates workflow `uses:` directives from `ecmwf-actions/` to `ecmwf/`.

No functional changes - the actions are identical, just relocated.

---
*This PR was created automatically.*
