### PR TITLE
PLUME-4: Fix plugin rejection when no group is accepted

### DIFF
--- a/src/plume/Negotiator.cc
+++ b/src/plume/Negotiator.cc
@@ -84,8 +84,10 @@ PluginDecision Negotiator::negotiate(const Protocol& offers, const Protocol& req
     }
 
     // 2) Check requested parameters (from the configuration)
-    // Here we check "groups" of requested parameters. A plugin can run if ANY of the "groups" are satisfied
+    // Here we check "groups" of requested parameters. A plugin can run if AT LEAST ONE of the "groups" are satisfied
     if (!config_params.empty()) {
+
+        bool any_group_accepted = false;
 
         for (const auto& param_group : config_params) {
 
@@ -107,6 +109,7 @@ PluginDecision Negotiator::negotiate(const Protocol& offers, const Protocol& req
 
             if (group_satisfied) {
                 eckit::Log::info() << " ---> Parameter Group Accepted!" << std::endl;
+                any_group_accepted = true;
 
                 // add all parameters in the group to the set "allRequestedParams"
                 allRequestedParams.insert(requested_params.begin(), requested_params.end());
@@ -114,6 +117,10 @@ PluginDecision Negotiator::negotiate(const Protocol& offers, const Protocol& req
             else {
                 eckit::Log::warning() << "---> Group rejected!" << std::endl;
             }
+        }
+
+        if (!any_group_accepted) {
+            return PluginDecision{false};
         }
     }
 

--- a/src/plume/Negotiator.cc
+++ b/src/plume/Negotiator.cc
@@ -84,7 +84,7 @@ PluginDecision Negotiator::negotiate(const Protocol& offers, const Protocol& req
     }
 
     // 2) Check requested parameters (from the configuration)
-    // Here we check "groups" of requested parameters. A plugin can run if AT LEAST ONE of the "groups" are satisfied
+    // Here we check "groups" of requested parameters. A plugin can run if AT LEAST ONE of the "groups" is satisfied
     if (!config_params.empty()) {
 
         bool any_group_accepted = false;

--- a/tests/core/test_plugin_params.cc
+++ b/tests/core/test_plugin_params.cc
@@ -294,8 +294,8 @@ CASE("test_cannot_derive_parameter") {
     // negotiate
     EXPECT_NO_THROW(plume::Manager::negotiate(data_cfg));
 
-    // plugin loaded but without parameter group
-    std::set<std::string> expected = {"I", "J", "K"};
+    // plugin did not load because the derived parameter could not be satisfied, so no active params
+    std::set<std::string> expected = {};
     std::set<std::string> activeParams(plume::Manager::getActiveParams().begin(),
                                        plume::Manager::getActiveParams().end());
     EXPECT_EQUAL(activeParams, expected);


### PR DESCRIPTION
### Description
When negotiating params from the configuration, Plume was not rejecting plugins that had no param group accepted, which is causing the plugin to fail later on. This is a small fix to ensure proper plugin rejection in case none of the groups is offered by the model.

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 