### PR TITLE
PLUME-62: WindAtHeight setup fix & geopotential checks

### DIFF
--- a/src/plume/data/FieldProvider.cc
+++ b/src/plume/data/FieldProvider.cc
@@ -8,6 +8,8 @@
  * granted to it by virtue of its status as an intergovernmental organisation nor
  * does it submit to any jurisdiction.
  */
+#include <sstream>
+
 #include "atlas/array.h"
 
 #include "plume/data/FieldProvider.h"
@@ -58,6 +60,33 @@ WindAtHeight::WindAtHeight(std::size_t height, AtlasFieldObservablePtr geopotent
         throw eckit::BadValue("Wind cannot be interpolated at heights higher than 80km", Here());
     }
 
+    // Validate field vertical shapes - fixed by the model at setup, never change
+    auto geoField  = geopotential_.lock();
+    auto windField = windComponent_.lock();
+    ASSERT(geoField && windField);
+
+    if (geoField->get().shape(1) < 2) {
+        std::ostringstream msg;
+        msg << "WindAtHeight setup failed: geopotential field has only " << geoField->get().shape(1)
+            << " vertical level(s). This usually means only surface orography was provided, but "
+            << "wind_at_height requires a vertically resolved geopotential profile.";
+        throw eckit::BadValue(msg.str(), Here());
+    }
+
+    if (windField->get().shape(1) < 2) {
+        std::ostringstream msg;
+        msg << "WindAtHeight setup failed: wind component field has only " << windField->get().shape(1)
+            << " vertical level(s), but wind_at_height requires at least 2 levels for interpolation.";
+        throw eckit::BadValue(msg.str(), Here());
+    }
+
+    if (geoField->get().shape(1) != windField->get().shape(1)) {
+        std::ostringstream msg;
+        msg << "WindAtHeight setup failed: geopotential and wind fields have inconsistent vertical dimensions "
+            << "(geopotential=" << geoField->get().shape(1) << ", wind=" << windField->get().shape(1) << ").";
+        throw eckit::BadValue(msg.str(), Here());
+    }
+
     // swap the target field array (which is a clone of the source) for a 2D array
     auto target = windAtHeight_.lock();
 
@@ -102,10 +131,15 @@ void WindAtHeight::update() {
                 }
             }
             if (!found) {
-                // when z_ is > Z[0] or < Z[N] there is a malformation that should be handled by the user
-                throw eckit::BadValue(
-                    "Wind interpolation failed: height not within geopotential range",
-                    Here());
+                const auto top = geopotential(i, 0);
+                const auto bottom = geopotential(i, wind.shape(1) - 1);
+                std::ostringstream msg;
+                msg << "Wind interpolation failed at point " << i
+                    << ": target geopotential z=" << z_
+                    << " is not bracketed by profile range [bottom=" << bottom
+                    << ", top=" << top << "]"
+                    << " (nlev=" << wind.shape(1) << ")";
+                throw eckit::BadValue(msg.str(), Here());
             }
         }
     };

--- a/src/plume/data/ModelData.cc
+++ b/src/plume/data/ModelData.cc
@@ -134,10 +134,7 @@ void ModelData::addDependency(const std::string& observer, const std::string& ob
     field_provider::StrategyArgList strategyArgs = strategyHelpers_.at(type)(config, valueMap_, observable, observer);
     // 3. create update strategy
     auto strategy = strategyRegistry_.at(type)(strategyArgs);
-    // 4. set initial observer value
-    strategy->update();
-    valueMap_.at(observer)->setUpdated(false);
-    // 5. attach strategy to observer
+    // 4. attach strategy to observer (initial value populated on first step run)
     subscriber->setUpdateStrategy(std::move(strategy));
 }
 

--- a/tests/core/test_atlas_model_data.cc
+++ b/tests/core/test_atlas_model_data.cc
@@ -115,9 +115,9 @@ CASE("test model data - observing atlas fields") {
     EXPECT_EQUAL(oberservableView.shape(0), 4);
     EXPECT_EQUAL(oberservableView(0), 1);
     EXPECT_EQUAL(oberserverView.shape(0), 4);
-    EXPECT_EQUAL(oberserverView(0), 2);
+    EXPECT_EQUAL(oberserverView(0), 1);  // cloned from source before first strategy run
     EXPECT_EQUAL(oberservableView(3), 4);
-    EXPECT_EQUAL(oberserverView(3), 5);
+    EXPECT_EQUAL(oberserverView(3), 4);  // cloned from source before first strategy run
 
     for (size_t i = 0; i < oberservableView.shape(0); ++i) {
         oberservableView(i) = 10 * i;

--- a/tests/core/test_model_data.cc
+++ b/tests/core/test_model_data.cc
@@ -227,8 +227,8 @@ CASE("test model data - observing params") {
     EXPECT_NOT(data.isUpdated("observable;dummy;00"));  // the newly created param is not marked as updated
 
     EXPECT_EQUAL(data.getParam<int>("observable"), 1);
-    EXPECT_EQUAL(data.getParam<int>("observable;dummy;00"), 2);
-    EXPECT_EQUAL(data.getParam<int>("observable", "00", "dummy"), 2);
+    EXPECT_EQUAL(data.getParam<int>("observable;dummy;00"), 0);  // zero-initialised; strategy not yet run
+    EXPECT_EQUAL(data.getParam<int>("observable", "00", "dummy"), 0);  // zero-initialised; strategy not yet run
     observableParam = 5;
     data.setUpdated({"observable"});
     EXPECT(data.isUpdated("observable;dummy;00"));


### PR DESCRIPTION
### Description
The geopotential passed to this strategy must be the full vertical profile, not just the 2d orography. This PR puts checks in place and better logging to validate the geopotential field passed. No strategy update is run at setup as the source field might still be at 0 as the setup runs before any model step has actually run so update might trigger false errors.

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 