### PR TITLE
PLUME-64: NWP Emulator Core API

### DIFF
--- a/.github/ci-config.yml
+++ b/.github/ci-config.yml
@@ -6,5 +6,9 @@ dependencies: |
   ecmwf/eccodes
 dependency_cmake_options: |
   ecmwf/atlas: "-DENABLE_FORTRAN=ON"
+cmake_options: |
+  -DPLUME_ENABLE_NWP_EMULATOR=ON
+  -DPLUME_ENABLE_NWP_EMULATOR_SINGLE_PRECISION=ON
+  -DPLUME_ENABLE_NWP_EMULATOR_DOUBLE_PRECISION=ON
 dependency_branch: develop
 parallelism_factor: 8

--- a/.github/ci-hpc-config.yml
+++ b/.github/ci-hpc-config.yml
@@ -18,6 +18,10 @@ mpi_on:
       - ecmwf/eccodes@develop
     dependency_cmake_options:
       - ecmwf/atlas:-DENABLE_FORTRAN=ON
+    cmake_options:
+      - -DPLUME_ENABLE_NWP_EMULATOR=ON
+      - -DPLUME_ENABLE_NWP_EMULATOR_SINGLE_PRECISION=ON
+      - -DPLUME_ENABLE_NWP_EMULATOR_DOUBLE_PRECISION=ON
     parallel: 64
     ntasks: 16
     env:
@@ -38,4 +42,11 @@ mpi_off:
       - ecmwf/eccodes@develop
     dependency_cmake_options:
       - ecmwf/atlas:-DENABLE_FORTRAN=ON
+    cmake_options:
+      - -DPLUME_ENABLE_NWP_EMULATOR=ON
+      - -DPLUME_ENABLE_NWP_EMULATOR_SINGLE_PRECISION=ON
+      - -DPLUME_ENABLE_NWP_EMULATOR_DOUBLE_PRECISION=ON
     parallel: 64
+    env:
+      - ECCODES_SAMPLES_PATH=$ECCODES_DIR/share/eccodes/samples
+      - ECCODES_DEFINITION_PATH=$ECCODES_DIR/share/eccodes/definitions

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,7 +49,7 @@ ecbuild_info("FCKIT_INCLUDE_DIRS ${FCKIT_INCLUDE_DIRS}")
 
 ############## NWP EMULATOR PRECISION & ENABLING
 ecbuild_add_option( FEATURE NWP_EMULATOR
-                    DEFAULT ON
+                    DEFAULT OFF
                     DESCRIPTION "Compile the NWP emulator"
                     REQUIRED_PACKAGES eccodes )
 

--- a/src/nwp_emulator/CMakeLists.txt
+++ b/src/nwp_emulator/CMakeLists.txt
@@ -22,7 +22,9 @@ foreach(prec sp dp)
                 config_reader.h
                 nwp_definitions.h
                 nwp_data_provider.h
+                nwp_emulator_core.h
                 nwp_data_provider.cc
+                nwp_emulator_core.cc
                 grib_file_reader.cc
                 config_reader.cc
                 config_reader_funcs.cc

--- a/src/nwp_emulator/nwp_data_provider.cc
+++ b/src/nwp_emulator/nwp_data_provider.cc
@@ -9,6 +9,9 @@
  * does it submit to any jurisdiction.
  */
 #include <sstream>
+#include <stdexcept>
+
+#include "atlas/array.h"
 
 #include "nwp_data_provider.h"
 
@@ -161,18 +164,122 @@ bool NWPDataProvider::LocalStepData() {
     return true;
 }
 
-int NWPDataProvider::findLevelIndex(atlas::Field& field, std::string levtype, std::string level) {
-    int level_idx =
-        std::distance(params_[field.name()][levtype].begin(),
-                      std::find(params_[field.name()][levtype].begin(), params_[field.name()][levtype].end(), level));
+int NWPDataProvider::findLevelIndex(atlas::Field& field, const std::string& levtype, const std::string& level) const {
+    auto shortIt = params_.find(field.name());
+    if (shortIt == params_.end()) {
+        throw std::out_of_range("field not available in provider");
+    }
+    auto levtypeIt = shortIt->second.find(levtype);
+    if (levtypeIt == shortIt->second.end()) {
+        throw std::out_of_range("levtype not available for field");
+    }
+
+    const auto levelIt = std::find(levtypeIt->second.begin(), levtypeIt->second.end(), level);
+    if (levelIt == levtypeIt->second.end()) {
+        throw std::out_of_range("level not available for field/levtype");
+    }
+
+    int level_idx = static_cast<int>(std::distance(levtypeIt->second.begin(), levelIt));
     // level_idx + size of previous levtypes in levelOrder
     std::vector<std::string> levelOrder = field.metadata().getStringVector("levelOrder");
-    for (int type_idx = 0; type_idx < levelOrder.size(); type_idx++) {
+    for (int type_idx = 0; type_idx < static_cast<int>(levelOrder.size()); type_idx++) {
         if (levelOrder[type_idx] == levtype) {
             break;
         }
-        level_idx += params_[field.name()][levelOrder[type_idx]].size();
+        const auto priorLevtypeIt = shortIt->second.find(levelOrder[type_idx]);
+        if (priorLevtypeIt == shortIt->second.end()) {
+            throw std::out_of_range("levelOrder references unknown levtype for field");
+        }
+        level_idx += static_cast<int>(priorLevtypeIt->second.size());
     }
     return level_idx;
+}
+
+std::vector<std::string> NWPDataProvider::getFieldKeys() const {
+    std::vector<std::string> keys;
+    for (const auto& shortNamePair: params_) {
+        const std::string& shortName = shortNamePair.first;
+        for (const auto& levtypePair: shortNamePair.second) {
+            const std::string& levtype = levtypePair.first;
+            for (const auto& level: levtypePair.second) {
+                keys.push_back(shortName + "," + levtype + "," + level);
+            }
+        }
+    }
+    std::sort(keys.begin(), keys.end());
+    return keys;
+}
+
+bool NWPDataProvider::extractFieldOverlay(const std::string& fieldKey,
+                                          std::vector<double>& lon,
+                                          std::vector<double>& lat,
+                                          std::vector<double>& values,
+                                          std::string& error) const {
+    lon.clear();
+    lat.clear();
+    values.clear();
+    error.clear();
+
+    std::stringstream ss(fieldKey);
+    std::string shortName;
+    std::string levtype;
+    std::string level;
+    std::getline(ss, shortName, ',');
+    std::getline(ss, levtype, ',');
+    std::getline(ss, level, ',');
+
+    if (shortName.empty() || levtype.empty() || level.empty()) {
+        error = "invalid field key format";
+        return false;
+    }
+
+    auto shortIt = params_.find(shortName);
+    if (shortIt == params_.end()) {
+        error = "field key not available in current provider";
+        return false;
+    }
+    auto levtypeIt = shortIt->second.find(levtype);
+    if (levtypeIt == shortIt->second.end()) {
+        error = "field key not available in current provider";
+        return false;
+    }
+
+    atlas::Field field;
+    try {
+        field = modelFieldSet_.field(shortName);
+    } catch (const std::exception&) {
+        error = "field not found in model fieldset";
+        return false;
+    }
+
+    int levelIndex = 0;
+    try {
+        levelIndex = findLevelIndex(field, levtype, level);
+    } catch (const std::exception& exc) {
+        error = std::string("requested field key not mapped to a backend level index: ") + exc.what();
+        return false;
+    }
+
+    if (levelIndex >= static_cast<int>(field.shape(1))) {
+        error = "requested field level index out of range";
+        return false;
+    }
+
+    const atlas::Field lonlatField = fs_.lonlat();
+    auto lonlatView = atlas::array::make_view<double, 2>(lonlatField);
+    auto valueView = atlas::array::make_view<FIELD_TYPE_REAL, 2>(field);
+
+    const atlas::idx_t nPoints = field.shape(0);
+    lon.reserve(nPoints);
+    lat.reserve(nPoints);
+    values.reserve(nPoints);
+
+    for (atlas::idx_t i = 0; i < nPoints; ++i) {
+        lon.push_back(lonlatView(i, atlas::LON));
+        lat.push_back(lonlatView(i, atlas::LAT));
+        values.push_back(static_cast<double>(valueView(i, levelIndex)));
+    }
+
+    return true;
 }
 }  // namespace nwp_emulator

--- a/src/nwp_emulator/nwp_data_provider.h
+++ b/src/nwp_emulator/nwp_data_provider.h
@@ -9,7 +9,10 @@
  * does it submit to any jurisdiction.
  */
 #pragma once
+#include <algorithm>
+#include <memory>
 #include <unordered_map>
+#include <vector>
 
 #include "eckit/config/LocalConfiguration.h"
 #include "eckit/config/YAMLConfiguration.h"
@@ -101,7 +104,7 @@ private:
      *
      * @return int The index of the second shape of the Atlas field where the data should go.
      */
-    int findLevelIndex(atlas::Field& field, std::string levtype, std::string level);
+    int findLevelIndex(atlas::Field& field, const std::string& levtype, const std::string& level) const;
 
 public:
     /**
@@ -133,5 +136,26 @@ public:
     atlas::FieldSet& getModelFieldSet() { return modelFieldSet_; }
     int getStep() const { return dataReader->getStep(); }
     size_t getLevels() const { return nLevels_; }
+
+    /**
+     * @brief Return all field keys exposed to the UI in `shortName,levtype,level` format.
+     */
+    std::vector<std::string> getFieldKeys() const;
+
+    /**
+     * @brief Extract one local rank overlay for a field key at the current step.
+     *
+     * The returned lon/lat/value arrays are rank-local and can be concatenated across ranks
+     * to build one global scatter overlay, which could be used by potential apps built on top of the emulator.
+     */
+    bool extractFieldOverlay(const std::string& fieldKey,
+                             std::vector<double>& lon,
+                             std::vector<double>& lat,
+                             std::vector<double>& values,
+                             std::string& error) const;
+
+    size_t rank() const { return rank_; }
+    size_t root() const { return root_; }
+    size_t nprocs() const { return nprocs_; }
 };
 }  // namespace nwp_emulator

--- a/src/nwp_emulator/nwp_data_provider.h
+++ b/src/nwp_emulator/nwp_data_provider.h
@@ -9,7 +9,10 @@
  * does it submit to any jurisdiction.
  */
 #pragma once
+#include <algorithm>
+#include <memory>
 #include <unordered_map>
+#include <vector>
 
 #include "eckit/config/LocalConfiguration.h"
 #include "eckit/config/YAMLConfiguration.h"
@@ -101,7 +104,7 @@ private:
      *
      * @return int The index of the second shape of the Atlas field where the data should go.
      */
-    int findLevelIndex(atlas::Field& field, std::string levtype, std::string level);
+    int findLevelIndex(atlas::Field& field, const std::string& levtype, const std::string& level) const;
 
 public:
     /**
@@ -133,5 +136,26 @@ public:
     atlas::FieldSet& getModelFieldSet() { return modelFieldSet_; }
     int getStep() const { return dataReader->getStep(); }
     size_t getLevels() const { return nLevels_; }
+
+    /**
+     * @brief Return all field keys exposed to the UI in `shortName,levtype,level` format.
+     */
+    std::vector<std::string> getFieldKeys() const;
+
+    /**
+     * @brief Extract one local rank overlay for a field key at the current step.
+     *
+     * The returned lon/lat/value arrays are rank-local and can be concatenated
+     * across ranks by the Python runtime to build one global scatter overlay.
+     */
+    bool extractFieldOverlay(const std::string& fieldKey,
+                             std::vector<double>& lon,
+                             std::vector<double>& lat,
+                             std::vector<double>& values,
+                             std::string& error) const;
+
+    size_t rank() const { return rank_; }
+    size_t root() const { return root_; }
+    size_t nprocs() const { return nprocs_; }
 };
 }  // namespace nwp_emulator

--- a/src/nwp_emulator/nwp_emulator.cc
+++ b/src/nwp_emulator/nwp_emulator.cc
@@ -11,21 +11,14 @@
 #include <iostream>
 #include <stdlib.h>
 
-#include "eckit/config/YAMLConfiguration.h"
-#include "eckit/filesystem/PathName.h"
-#include "eckit/mpi/Comm.h"
+#include "eckit/log/Log.h"
 
-#include "atlas/field/Field.h"
 #include "atlas/library.h"
-#include "atlas/option/Options.h"
 #include "atlas/parallel/mpi/mpi.h"
 #include "atlas/runtime/AtlasTool.h"
 
-#include "plume/Manager.h"
-#include "plume/data/ModelData.h"
-
-#include "nwp_data_provider.h"
 #include "nwp_definitions.h"
+#include "nwp_emulator_core.h"
 
 using namespace nwp_emulator;
 
@@ -48,6 +41,7 @@ class NWPEmulator final : public atlas::AtlasTool {
 
 public:
     NWPEmulator(int argc, char** argv) : dataSourceType_(DataSourceType::INVALID), atlas::AtlasTool(argc, argv) {
+        // Preserve the existing CLI surface while delegating execution to the core.
         add_option(new SimpleOption<std::string>("grib-src", "Path to GRIB files source"));
         add_option(new SimpleOption<std::string>("config-src", "Path to emulator config file"));
         add_option(new SimpleOption<std::string>("plume-cfg", "Path to Plume configuration"));
@@ -57,29 +51,12 @@ private:
     std::string dataSourcePath_;
     DataSourceType dataSourceType_;
 
-    /// Plume members if needed
+    // Empty means dry-run mode (no Plume execution).
     std::string plumeConfigPath_;
-    plume::data::ModelData plumeData_;
-
-    /**
-     * @brief Sets up Plume framework and load plugins compatible with model params.
-     *
-     * @param dataProvider The object that provides the data for the Atlas fields offered by the emulated model.
-     *
-     * @return true if Plume configuration, negotiation and feeding are successful, false otherwise.
-     */
-    bool setupPlume(NWPDataProvider& dataProvider);
-
-    /**
-     * @brief Update necessary parameters offered to Plume other than Atlas fields, and run the plugins for the step.
-     *
-     * @param step The internal model step number.
-     */
-    void runPlume(int step);
 };
 
 int NWPEmulator::execute(const Args& args) {
-    // Emulator configuration
+    // Parse CLI options and normalize to core run options.
     std::string gribSrcArg;
     if (args.get("grib-src", gribSrcArg)) {
         dataSourcePath_ = gribSrcArg;
@@ -100,81 +77,17 @@ int NWPEmulator::execute(const Args& args) {
     }
     args.get("plume-cfg", plumeConfigPath_);
 
-    size_t root   = 0;
-    size_t nprocs = eckit::mpi::comm().size();
-    size_t rank   = eckit::mpi::comm().rank();
+    // The AtlasTool wrapper is now a thin adapter over the reusable core.
+    NWPEmulatorCore core;
+    NWPEmulatorRunOptions options{dataSourceType_, dataSourcePath_, plumeConfigPath_};
 
-    NWPDataProvider dataProvider(dataSourceType_, eckit::PathName{dataSourcePath_}, rank, root, nprocs);
-
-    // Plume loading if a Plume configuration file has been passed, emulator dry run otherwise
-    if (!plumeConfigPath_.empty()) {
-        eckit::Log::info() << "The emulator will run Plume with configuration '" << plumeConfigPath_ << "'"
-                           << std::endl;
-        setupPlume(dataProvider);
-    }
-
-    // Run the emulator
-    while (dataProvider.getStepData()) {
-        // This is a model step
-        if (!plumeConfigPath_.empty()) {
-            runPlume(dataProvider.getStep());
-        }
-        eckit::mpi::comm().barrier();
-    }
-
-    // Tear down where appropriate and wait for all processes before finishing
-    if (!plumeConfigPath_.empty()) {
-        plume::Manager::teardown();
-    }
-
-    eckit::mpi::comm().barrier();
-    std::cout << "Process " << rank << " finished..." << std::endl;
-    eckit::Log::info() << "Emulator run completed..." << std::endl;
-    return 0;
-}
-
-bool NWPEmulator::setupPlume(NWPDataProvider& dataProvider) {
-    plume::Manager::configure(eckit::YAMLConfiguration(eckit::PathName(plumeConfigPath_)));
-
-    // Set all the non-const params updated flags to true so it doesn't have to be done at run step
-    std::vector<std::string> updatingParams;
-
-    plume::Protocol offers;  /// Define data offered by Plume
-    offers.offer<int>("NSTEP", "always", "Simulation Step");
-    updatingParams.push_back("NSTEP");
-    offers.offer<double>("TSTEP", "always", "Simulation Time Step");
-    offers.offer<size_t>("NFLEVG", "always", "Number of vertical levels");
-    offers.offer<double>("WSTEP", "always", "Wave simulation time");
-    updatingParams.push_back("WSTEP");
-    auto fields = dataProvider.getModelFieldSet();
-    for (const auto& field: fields) {
-        offers.offer<atlas::Field>(field.name(), "on-request", field.name());
-    }
-    plume::Manager::negotiate(offers);
-    plumeData_.createParam("NSTEP", 0);  /// Initialise parameters
-    plumeData_.createParam("TSTEP", 900.0);
-    plumeData_.createParam("NFLEVG", dataProvider.getLevels());
-    plumeData_.createParam("WSTEP", 0.0);
-    for (auto& field: fields) {
-        if (plume::Manager::isParamRequested(field.name())) {
-            plumeData_.provideParam(field.name(), &field);
-            updatingParams.push_back(field.name());
-        }
-    }
-
-    plume::Manager::feedPlugins(plumeData_);
-
-    plumeData_.setUpdated(updatingParams);
-    return true;
-}
-
-void NWPEmulator::runPlume(int step) {
-    plume::Manager::run();
-    plumeData_.updateParam("NSTEP", step);
-    plumeData_.updateParam("WSTEP", std::ceil(step * plumeData_.getParam<double>("TSTEP")));
+    NWPEmulatorRunResult result = core.execute(options);
+    return result.returnCode;
 }
 
 int main(int argc, char** argv) {
+    // Atlas logging is expected by the existing emulator toolchain and remains
+    // configured at process startup before the AtlasTool lifecycle begins.
     setenv("ATLAS_LOG_FILE", "true", 1);
     NWPEmulator emulator(argc, argv);
     return emulator.start();

--- a/src/nwp_emulator/nwp_emulator_core.cc
+++ b/src/nwp_emulator/nwp_emulator_core.cc
@@ -1,0 +1,243 @@
+/*
+ * (C) Copyright 2025- ECMWF.
+ *
+ * This software is licensed under the terms of the Apache Licence Version 2.0
+ * which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * In applying this licence, ECMWF does not waive the privileges and immunities
+ * granted to it by virtue of its status as an intergovernmental organisation nor
+ * does it submit to any jurisdiction.
+ */
+#include <cmath>
+#include <iostream>
+#include <limits>
+#include <stdexcept>
+
+#include "eckit/config/YAMLConfiguration.h"
+#include "eckit/filesystem/PathName.h"
+#include "eckit/mpi/Comm.h"
+
+#include "atlas/field/Field.h"
+
+#include "plume/Manager.h"
+
+#include "nwp_emulator_core.h"
+
+namespace nwp_emulator {
+
+NWPEmulatorRunResult NWPEmulatorCore::execute(const NWPEmulatorRunOptions& options) {
+    NWPEmulatorRunResult result;
+    if (!validateRunOptions(options)) {
+        result.returnCode = 1;
+        return result;
+    }
+
+    if (!setupDataProvider(options)) {
+        result.returnCode = 1;
+        return result;
+    }
+
+    if (!plumeConfigPath_.empty()) {
+        if (!setupPlumeProvider()) {
+            result.returnCode = 1;
+            finalizePlume();
+            return result;
+        }
+        result.plumeRun = true;
+    }
+
+    while (runStep()) {
+        result.lastStepRun = currentStep();
+    }
+
+    finalizeRun();
+    return result;
+}
+
+bool NWPEmulatorCore::validateRunOptions(const NWPEmulatorRunOptions& options) const {
+    if (options.dataSourcePath.empty() || options.dataSourceType == DataSourceType::INVALID) {
+        eckit::Log::error() << "Invalid emulator run options" << std::endl;
+        return false;
+    }
+    return true;
+}
+
+bool NWPEmulatorCore::setupDataProvider(const NWPEmulatorRunOptions& options) {
+    if (!validateRunOptions(options)) {
+        return false;
+    }
+
+    plumeConfigPath_ = options.plumeConfigPath;
+    plumeInitialised_ = false;
+
+    const size_t root   = 0;
+    const size_t nprocs = eckit::mpi::comm().size();
+    const size_t rank   = eckit::mpi::comm().rank();
+    dataProvider_ = std::make_unique<NWPDataProvider>(
+        options.dataSourceType,
+        eckit::PathName{options.dataSourcePath},
+        rank,
+        root,
+        nprocs
+    );
+    return true;
+}
+
+bool NWPEmulatorCore::setupPlumeProvider() {
+    if (!dataProvider_) {
+        eckit::Log::error() << "Data provider must be initialized before plume setup" << std::endl;
+        return false;
+    }
+
+    if (plumeConfigPath_.empty()) {
+        return true;
+    }
+
+    eckit::Log::info() << "The emulator will run Plume with configuration '" << plumeConfigPath_ << "'"
+                       << std::endl;
+    plumeInitialised_ = setupPlume(*dataProvider_);
+    return plumeInitialised_;
+}
+
+bool NWPEmulatorCore::runStep() {
+    if (!dataProvider_) {
+        return false;
+    }
+
+    try {
+        if (!dataProvider_->getStepData()) {
+            return false;
+        }
+
+        if (plumeInitialised_) {
+            runPlume(dataProvider_->getStep());
+        }
+
+        // Keep ranks in lockstep during healthy execution.
+        eckit::mpi::comm().barrier();
+        return true;
+    }
+    catch (const std::exception& ex) {
+        eckit::Log::error() << "runStep failed on rank " << eckit::mpi::comm().rank() << ": " << ex.what()
+                            << std::endl;
+        // Fail all ranks immediately to avoid barrier deadlocks when one rank throws.
+        eckit::mpi::comm().abort(1);
+        return false;
+    }
+}
+
+void NWPEmulatorCore::finalizePlume() {
+    if (plumeInitialised_) {
+        plume::Manager::teardown();
+        plumeInitialised_ = false;
+    }
+}
+
+void NWPEmulatorCore::finalizeRun() {
+    finalizePlume();
+
+    const size_t rank = eckit::mpi::comm().rank();
+    eckit::mpi::comm().barrier();
+    std::cout << "Process " << rank << " finished..." << std::endl;
+    eckit::Log::info() << "Emulator run completed..." << std::endl;
+}
+
+int NWPEmulatorCore::currentStep() const {
+    if (!dataProvider_) {
+        return -1;
+    }
+    return dataProvider_->getStep();
+}
+
+std::vector<std::string> NWPEmulatorCore::availableFieldKeys() const {
+    if (!dataProvider_) {
+        return {};
+    }
+    return dataProvider_->getFieldKeys();
+}
+
+NWPFieldOverlaySnapshot NWPEmulatorCore::getFieldOverlaySnapshot(const std::string& fieldKey) const {
+    NWPFieldOverlaySnapshot snapshot;
+    snapshot.fieldKey = fieldKey;
+
+    if (!dataProvider_) {
+        throw std::runtime_error("Data provider must be initialized before field export");
+    }
+
+    std::string error;
+    const bool ok = dataProvider_->extractFieldOverlay(
+        fieldKey,
+        snapshot.lon,
+        snapshot.lat,
+        snapshot.values,
+        error
+    );
+    if (!ok) {
+        throw std::runtime_error("Field overlay export failed for " + fieldKey + ": " + error);
+    }
+
+    snapshot.step = currentStep();
+    snapshot.rank = dataProvider_->rank();
+    snapshot.root = dataProvider_->root();
+    snapshot.nprocs = dataProvider_->nprocs();
+    return snapshot;
+}
+
+bool NWPEmulatorCore::setupPlume(NWPDataProvider& dataProvider) {
+    plume::Manager::configure(eckit::YAMLConfiguration(eckit::PathName(plumeConfigPath_)));
+
+    const size_t modelLevels = dataProvider.getLevels();
+    if (modelLevels > static_cast<size_t>(std::numeric_limits<int>::max())) {
+        throw std::runtime_error("NFLEVG exceeds supported int range");
+    }
+    const int nflevg = static_cast<int>(modelLevels);
+
+    // Record parameters updated every step so plugins do not need to infer which
+    // values have changed between invocations.
+    plumeUpdatingParams_.clear();
+
+    plume::Protocol offers;  // Define data offered by the emulator to Plume.
+    offers.offer<int>("NSTEP", "always", "Simulation Step");
+    plumeUpdatingParams_.push_back("NSTEP");
+    offers.offer<double>("TSTEP", "always", "Simulation Time Step");
+    offers.offer<int>("NFLEVG", "always", "Number of vertical levels");
+    offers.offer<double>("WSTEP", "always", "Wave simulation time");
+    plumeUpdatingParams_.push_back("WSTEP");
+
+    // Offer every model field so plugin negotiation can decide which fields are
+    // actually needed for the configured plugin set.
+    auto& fields = dataProvider.getModelFieldSet();
+    for (const auto& field: fields) {
+        offers.offer<atlas::Field>(field.name(), "on-request", field.name());
+    }
+    plume::Manager::negotiate(offers);
+
+    // Scalar parameters are initialised once before the first plugin step.
+    plumeData_.createParam("NSTEP", 0);
+    plumeData_.createParam("TSTEP", 900.0);
+    plumeData_.createParam("NFLEVG", nflevg);
+    plumeData_.createParam("WSTEP", 0.0);
+
+    // Only bind fields that plugins explicitly requested during negotiation.
+    for (auto& field: fields) {
+        if (plume::Manager::isParamRequested(field.name())) {
+            plumeData_.provideParam(field.name(), &field);
+            plumeUpdatingParams_.push_back(field.name());
+        }
+    }
+
+    plume::Manager::feedPlugins(plumeData_);
+    return true;
+}
+
+void NWPEmulatorCore::runPlume(int step) {
+    // Update step metadata and mark backing fields as updated only after the
+    // provider has populated this step's data.
+    plumeData_.updateParam("NSTEP", step);
+    plumeData_.updateParam("WSTEP", std::ceil(step * plumeData_.getParam<double>("TSTEP")));
+    plumeData_.setUpdated(plumeUpdatingParams_);
+
+    plume::Manager::run();
+}
+
+}  // namespace nwp_emulator

--- a/src/nwp_emulator/nwp_emulator_core.h
+++ b/src/nwp_emulator/nwp_emulator_core.h
@@ -1,0 +1,118 @@
+/*
+ * (C) Copyright 2025- ECMWF.
+ *
+ * This software is licensed under the terms of the Apache Licence Version 2.0
+ * which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * In applying this licence, ECMWF does not waive the privileges and immunities
+ * granted to it by virtue of its status as an intergovernmental organisation nor
+ * does it submit to any jurisdiction.
+ */
+#pragma once
+
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "plume/data/ModelData.h"
+
+#include "nwp_data_provider.h"
+
+namespace nwp_emulator {
+
+/**
+ * @struct NWPEmulatorRunOptions
+ * @brief Typed execution options for a single emulator run.
+ *
+ * This is the stable contract that higher-level adapters should populate before
+ * delegating to the reusable emulator core. It deliberately mirrors the current
+ * CLI semantics: exactly one data source and an optional Plume configuration.
+ */
+struct NWPEmulatorRunOptions {
+    DataSourceType dataSourceType = DataSourceType::INVALID;
+    std::string dataSourcePath;
+    std::string plumeConfigPath;
+};
+
+/**
+ * @struct NWPEmulatorRunResult
+ * @brief Minimal execution outcome returned by the core.
+ *
+ * This result is intentionally small for now. It records whether the run
+ * succeeded, whether Plume was enabled, and the last completed model step so
+ * future adapters can expose richer status without parsing log output.
+ */
+struct NWPEmulatorRunResult {
+    int returnCode  = 0;
+    bool plumeRun   = false;
+    int lastStepRun = -1;
+};
+
+struct NWPFieldOverlaySnapshot {
+    std::string fieldKey;
+    std::vector<double> lon;
+    std::vector<double> lat;
+    std::vector<double> values;
+    int step = -1;
+    size_t rank = 0;
+    size_t root = 0;
+    size_t nprocs = 1;
+};
+
+/**
+ * @class NWPEmulatorCore
+ * @brief Reusable emulator backend independent from the AtlasTool CLI wrapper.
+ *
+ * The core owns the actual emulator run orchestration: data-provider setup,
+ * optional Plume negotiation, step loop execution, and final teardown. The CLI
+ * executable, and later Python bindings, should delegate into this class rather
+ * than duplicating execution logic.
+ */
+class NWPEmulatorCore final {
+public:
+    /**
+     * @brief Execute one emulator run from normalized options.
+     *
+     * @param options Fully normalized execution options.
+     *
+     * @return NWPEmulatorRunResult Summary of the completed run.
+     */
+    NWPEmulatorRunResult execute(const NWPEmulatorRunOptions& options);
+    bool validateRunOptions(const NWPEmulatorRunOptions& options) const;
+    bool setupDataProvider(const NWPEmulatorRunOptions& options);
+    bool setupPlumeProvider();
+    bool runStep();
+    void finalizePlume();
+    void finalizeRun();
+    int currentStep() const;
+    std::vector<std::string> availableFieldKeys() const;
+    NWPFieldOverlaySnapshot getFieldOverlaySnapshot(const std::string& fieldKey) const;
+
+private:
+    /**
+     * @brief Configure Plume and register all requested fields and scalar params.
+     *
+     * @param dataProvider Source of model fields exposed by the emulator.
+     *
+     * @return true when Plume setup completed successfully.
+     */
+    bool setupPlume(NWPDataProvider& dataProvider);
+
+    /**
+     * @brief Run Plume for the current step and update derived scalar values.
+     *
+     * @param step Current emulator step number.
+     */
+    void runPlume(int step);
+
+    /// Empty means dry-run mode with emulator data generation only.
+    std::string plumeConfigPath_;
+
+    /// Shared param store passed to Plume across all steps of a single run.
+    plume::data::ModelData plumeData_;
+    std::vector<std::string> plumeUpdatingParams_;
+    bool plumeInitialised_{false};
+    std::unique_ptr<NWPDataProvider> dataProvider_;
+};
+
+}  // namespace nwp_emulator

--- a/src/nwp_emulator/nwp_emulator_pybind.cc
+++ b/src/nwp_emulator/nwp_emulator_pybind.cc
@@ -1,0 +1,171 @@
+/*
+ * (C) Copyright 2025- ECMWF.
+ *
+ * This software is licensed under the terms of the Apache Licence Version 2.0
+ * which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * In applying this licence, ECMWF does not waive the privileges and immunities
+ * granted to it by virtue of its status as an intergovernmental organisation nor
+ * does it submit to any jurisdiction.
+ */
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+#include <cstdlib>
+
+#include "eckit/runtime/Main.h"
+
+#include "nwp_emulator_core.h"
+
+namespace py = pybind11;
+
+#ifndef NWP_EMULATOR_PYTHON_MODULE_NAME
+#define NWP_EMULATOR_PYTHON_MODULE_NAME nwp_emulator_core
+#endif
+
+namespace nwp_emulator {
+
+namespace {
+
+void ensure_runtime_initialised() {
+    // Keep Atlas/eckit runtime expectations aligned with the CLI path.
+    ::setenv("ATLAS_LOG_FILE", "true", 1);
+
+    if (!eckit::Main::ready()) {
+        static const int argc = 1;
+        static char* argv[]   = {const_cast<char*>("nwp_emulator_pybind"), nullptr};
+        eckit::Main::initialise(argc, argv);
+    }
+
+    // Note: MPI initialization is handled by eckit::Main::initialise() above.
+    // When workers are spawned under mpirun, the MPI environment is already
+    // set up by the MPI launcher, and the eckit runtime will use it properly.
+}
+
+}  // namespace
+
+/**
+ * @brief Register the initial Python-facing bindings for the reusable emulator core.
+ *
+ * This scaffold exposes the typed execution surface: source-type enum, run options,
+ * run result, and execute entrypoints. For multi-rank execution, workers
+ * are spawned under mpirun which establishes the MPI context before Python imports
+ * this module. The eckit::Main::initialise() call ensures proper runtime setup.
+ */
+PYBIND11_MODULE(NWP_EMULATOR_PYTHON_MODULE_NAME, module) {
+    module.doc() = "Python bindings for the reusable NWP emulator core";
+
+    py::enum_<DataSourceType>(module, "DataSourceType")
+        .value("GRIB", DataSourceType::GRIB)
+        .value("CONFIG", DataSourceType::CONFIG)
+        .value("INVALID", DataSourceType::INVALID);
+
+    py::class_<NWPEmulatorRunOptions>(module, "RunOptions")
+        .def(py::init<>())
+        .def_readwrite("data_source_type", &NWPEmulatorRunOptions::dataSourceType)
+        .def_readwrite("data_source_path", &NWPEmulatorRunOptions::dataSourcePath)
+        .def_readwrite("plume_config_path", &NWPEmulatorRunOptions::plumeConfigPath);
+
+    py::class_<NWPEmulatorRunResult>(module, "RunResult")
+        .def(py::init<>())
+        .def_readonly("return_code", &NWPEmulatorRunResult::returnCode)
+        .def_readonly("plume_run", &NWPEmulatorRunResult::plumeRun)
+        .def_readonly("last_step_run", &NWPEmulatorRunResult::lastStepRun);
+
+    py::class_<NWPEmulatorCore>(module, "NWPEmulatorCore")
+        .def(py::init<>())
+        .def(
+            "validate_run_options",
+            [](NWPEmulatorCore& core, const NWPEmulatorRunOptions& options) {
+                ensure_runtime_initialised();
+                return core.validateRunOptions(options);
+            },
+            py::arg("options")
+        )
+        .def(
+            "setup_data_provider",
+            [](NWPEmulatorCore& core, const NWPEmulatorRunOptions& options) {
+                ensure_runtime_initialised();
+                return core.setupDataProvider(options);
+            },
+            py::arg("options")
+        )
+        .def(
+            "setup_plume_provider",
+            [](NWPEmulatorCore& core) {
+                ensure_runtime_initialised();
+                return core.setupPlumeProvider();
+            }
+        )
+        .def(
+            "run_step",
+            [](NWPEmulatorCore& core) {
+                ensure_runtime_initialised();
+                return core.runStep();
+            }
+        )
+        .def(
+            "finalize_plume",
+            [](NWPEmulatorCore& core) {
+                ensure_runtime_initialised();
+                core.finalizePlume();
+            }
+        )
+        .def(
+            "finalize_run",
+            [](NWPEmulatorCore& core) {
+                ensure_runtime_initialised();
+                core.finalizeRun();
+            }
+        )
+        .def(
+            "current_step",
+            [](NWPEmulatorCore& core) {
+                ensure_runtime_initialised();
+                return core.currentStep();
+            }
+        )
+        .def(
+            "available_field_keys",
+            [](NWPEmulatorCore& core) {
+                ensure_runtime_initialised();
+                return core.availableFieldKeys();
+            }
+        )
+        .def(
+            "get_field_overlay_snapshot",
+            [](NWPEmulatorCore& core, const std::string& field_key) {
+                ensure_runtime_initialised();
+                const auto snapshot = core.getFieldOverlaySnapshot(field_key);
+                py::dict payload;
+                payload["field_key"] = snapshot.fieldKey;
+                payload["lon"] = snapshot.lon;
+                payload["lat"] = snapshot.lat;
+                payload["values"] = snapshot.values;
+                payload["step"] = snapshot.step;
+                payload["rank"] = snapshot.rank;
+                payload["root"] = snapshot.root;
+                payload["nprocs"] = snapshot.nprocs;
+                return payload;
+            },
+            py::arg("field_key")
+        )
+        .def(
+            "execute",
+            [](NWPEmulatorCore& core, const NWPEmulatorRunOptions& options) {
+                ensure_runtime_initialised();
+                return core.execute(options);
+            },
+            py::arg("options"));
+
+    module.def(
+        "execute",
+        [](const NWPEmulatorRunOptions& options) {
+            ensure_runtime_initialised();
+            NWPEmulatorCore core;
+            return core.execute(options);
+        },
+        py::arg("options"),
+        "Execute a single emulator run using normalized run options.");
+}
+
+}  // namespace nwp_emulator

--- a/tests/nwp_emulator/CMakeLists.txt
+++ b/tests/nwp_emulator/CMakeLists.txt
@@ -28,6 +28,17 @@ ecbuild_get_test_multidata(
 foreach(prec sp dp)
     if (HAVE_NWP_EMULATOR_${prec})
         ecbuild_add_test(
+            TARGET      plume_test_nwp_core_parity_${prec}
+            SOURCES     test_core_parity.cc
+            LIBS        plume_nwp_emulator_${prec}
+            DEFINITIONS ${NWP_EMULATOR_DEFINITIONS_${prec}}
+            ENVIRONMENT
+                TEST_DATA_DIR=${CMAKE_CURRENT_SOURCE_DIR}/data/
+                NWP_EMULATOR_RUN_BIN=$<TARGET_FILE:nwp_emulator_run_${prec}.x>
+                OMP_NUM_THREADS=1
+        )
+
+        ecbuild_add_test(
             TARGET      plume_test_nwp_grib_${prec}
             SOURCES     test_grib_reader.cc
             LIBS        plume_nwp_emulator_${prec}

--- a/tests/nwp_emulator/test_core_parity.cc
+++ b/tests/nwp_emulator/test_core_parity.cc
@@ -1,0 +1,79 @@
+/*
+ * (C) Copyright 2025- ECMWF.
+ *
+ * This software is licensed under the terms of the Apache Licence Version 2.0
+ * which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * In applying this licence, ECMWF does not waive the privileges and immunities
+ * granted to it by virtue of its status as an intergovernmental organisation nor
+ * does it submit to any jurisdiction.
+ */
+
+#include <cstdlib>
+#include <string>
+
+#include "eckit/filesystem/PathName.h"
+#include "eckit/testing/Test.h"
+
+#include "nwp_emulator/nwp_definitions.h"
+#include "nwp_emulator/nwp_emulator_core.h"
+
+using namespace eckit::testing;
+using namespace nwp_emulator;
+
+namespace {
+
+eckit::PathName getenv_or_empty(const char* key) {
+    const char* value = std::getenv(key);
+    return value ? eckit::PathName(value) : eckit::PathName();
+}
+
+}  // namespace
+
+namespace plume::test {
+
+CASE("test_core_execute_invalid_options") {
+    NWPEmulatorCore core;
+    NWPEmulatorRunOptions options;
+
+    NWPEmulatorRunResult result = core.execute(options);
+    EXPECT_EQUAL(result.returnCode, 1);
+    EXPECT(!result.plumeRun);
+    EXPECT_EQUAL(result.lastStepRun, -1);
+}
+
+CASE("test_core_and_cli_adapter_parity_dry_run") {
+    const eckit::PathName testDataDir = getenv_or_empty("TEST_DATA_DIR");
+    const eckit::PathName runBin = getenv_or_empty("NWP_EMULATOR_RUN_BIN");
+
+    EXPECT_NOT_EQUAL(testDataDir.asString(), "/");
+    EXPECT_NOT_EQUAL(runBin.asString(), "/");
+
+    const eckit::PathName configPath = testDataDir + "valid_config.yml";
+
+    NWPEmulatorCore core;
+    NWPEmulatorRunOptions options;
+    options.dataSourceType = DataSourceType::CONFIG;
+    options.dataSourcePath = configPath.asString();
+
+    NWPEmulatorRunResult coreResult = core.execute(options);
+
+    const std::string cliCommand = runBin.asString() + " --config-src=" + configPath.asString();
+    const int cliStatus = std::system(cliCommand.c_str());
+
+    const bool coreSuccess = (coreResult.returnCode == 0);
+    const bool cliSuccess = (cliStatus == 0);
+
+    // Parity criterion for this first integration test: both paths should agree
+    // on success/failure outcome for the same normalized dry-run configuration.
+    EXPECT_EQUAL(coreSuccess, cliSuccess);
+    if (coreSuccess) {
+        EXPECT(coreResult.lastStepRun >= 0);
+    }
+}
+
+}  // namespace plume::test
+
+int main(int argc, char** argv) {
+    return run_tests(argc, argv);
+}


### PR DESCRIPTION
### Description

This PR refactors the emulator to expose its core API in C++ and Python in prevision of future apps being built on top, it also fixes a type bug which caused the EE plugin CI to fail.
The second commit turns it off by default, as was previously discussed to keep the emulator completely out of ifs bundles. It is activated in the CI to ensure tests pass.

The python bindings are added but not used nor tested in this PR but exposed for future usage.

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 