### PR TITLE
PLUME-67: Support for multiple hook points through states

### DIFF
--- a/cmake/generate_plume_tags_fortran.cmake
+++ b/cmake/generate_plume_tags_fortran.cmake
@@ -1,0 +1,50 @@
+# Generates a Fortran module with plume tag constants from TagDefinitions.def.
+
+if(NOT DEFINED INPUT)
+  message(FATAL_ERROR "INPUT is required")
+endif()
+
+if(NOT DEFINED OUTPUT)
+  message(FATAL_ERROR "OUTPUT is required")
+endif()
+
+file(READ "${INPUT}" TAG_DEFINITIONS_CONTENT)
+string(REPLACE "\r\n" "\n" TAG_DEFINITIONS_CONTENT "${TAG_DEFINITIONS_CONTENT}")
+string(REPLACE "\r" "\n" TAG_DEFINITIONS_CONTENT "${TAG_DEFINITIONS_CONTENT}")
+
+string(REGEX MATCHALL "PLUME_TAG\\([ \t]*[A-Z0-9_]+[ \t]*,[ \t]*\"[^\"]+\"[ \t]*\\)" TAG_DEFINITION_LINES "${TAG_DEFINITIONS_CONTENT}")
+
+if(NOT TAG_DEFINITION_LINES)
+  message(FATAL_ERROR "No PLUME_TAG(...) definitions found in ${INPUT}")
+endif()
+
+set(FORTRAN_CONSTANTS "")
+set(TAG_COUNT 0)
+
+foreach(TAG_LINE IN LISTS TAG_DEFINITION_LINES)
+  string(REGEX REPLACE "PLUME_TAG\\([ \t]*([A-Z0-9_]+)[ \t]*,[ \t]*\"([^\"]+)\"[ \t]*\\)" "\\1;\\2" TAG_PARTS "${TAG_LINE}")
+  list(GET TAG_PARTS 0 TAG_ID)
+  list(GET TAG_PARTS 1 TAG_NAME)
+
+  string(APPEND FORTRAN_CONSTANTS "integer(c_int), parameter, public :: PLUME_TAG_${TAG_ID} = ${TAG_COUNT}\n")
+  string(APPEND FORTRAN_CONSTANTS "character(len=*), parameter, public :: PLUME_TAG_NAME_${TAG_ID} = \"${TAG_NAME}\"\n")
+
+  math(EXPR TAG_COUNT "${TAG_COUNT} + 1")
+endforeach()
+
+set(MODULE_TEXT "! Auto-generated from TagDefinitions.def. Do not edit by hand.\n")
+string(APPEND MODULE_TEXT "module plume_tags_module\n")
+string(APPEND MODULE_TEXT "\n")
+string(APPEND MODULE_TEXT "use iso_c_binding, only : c_int\n")
+string(APPEND MODULE_TEXT "\n")
+string(APPEND MODULE_TEXT "implicit none\n")
+string(APPEND MODULE_TEXT "private\n")
+string(APPEND MODULE_TEXT "\n")
+string(APPEND MODULE_TEXT "${FORTRAN_CONSTANTS}")
+string(APPEND MODULE_TEXT "integer(c_int), parameter, public :: PLUME_TAG_COUNT = ${TAG_COUNT}\n")
+string(APPEND MODULE_TEXT "\n")
+string(APPEND MODULE_TEXT "end module plume_tags_module\n")
+
+get_filename_component(OUTPUT_DIR "${OUTPUT}" DIRECTORY)
+file(MAKE_DIRECTORY "${OUTPUT_DIR}")
+file(WRITE "${OUTPUT}" "${MODULE_TEXT}")

--- a/examples/example1.c
+++ b/examples/example1.c
@@ -58,7 +58,7 @@ int main(int argc, char** argv){
 
     // Run all plugins for several iterations
     for(int i=0; i<10; i++) {
-      plume_manager_run(mgr_handle);
+      plume_manager_run(mgr_handle, PLUME_TAG_ID_RUN, false, PLUME_TAG_ID_RUN);
 
       // e.g. update parameters..
       param_i++;

--- a/src/plume/CMakeLists.txt
+++ b/src/plume/CMakeLists.txt
@@ -15,10 +15,30 @@ ecbuild_configure_file( plume_version.cc.in  plume_version.cc )
 install(FILES
 			${CMAKE_CURRENT_BINARY_DIR}/plume_config.h
 			${CMAKE_CURRENT_BINARY_DIR}/plume_version.h
+            ${CMAKE_CURRENT_SOURCE_DIR}/TagDefinitions.def
 		DESTINATION
 			${INSTALL_INCLUDE_DIR}/plume )
 
 
+
+# #################### Plume state ######################
+ecbuild_add_library(
+    TARGET plume_state
+    INSTALL_HEADERS LISTED
+    HEADER_DESTINATION
+        ${INSTALL_INCLUDE_DIR}/plume
+    SOURCES
+        TagDefinitions.def
+        PlumeTag.h
+        PlumeTag.cc
+        PlumeState.h
+        PlumeState.cc
+    PUBLIC_INCLUDES
+       $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}/src>
+       $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/src>
+    PUBLIC_LIBS
+        eckit
+)
 
 # #################### Plume plugin ######################
 set(PLUGIN_FILES_H    
@@ -69,6 +89,7 @@ ecbuild_add_library(
     PUBLIC_LIBS
         atlas
         eckit
+        plume_state
 )
 
 # #################### PLUME plugin manager ######################
@@ -111,6 +132,7 @@ ecbuild_add_library(
     PUBLIC_LIBS        
         atlas
         eckit
+        plume_state
     PRIVATE_LIBS        
         plume_plugin
 )

--- a/src/plume/Manager.cc
+++ b/src/plume/Manager.cc
@@ -26,6 +26,7 @@
 #include "plume/PluginConfig.h"
 #include "plume/PluginCore.h"
 #include "plume/PluginHandler.h"
+#include "plume/PlumeState.h"
 #include "plume/Protocol.h"
 #include "plume/data/DataChecker.h"
 #include "plume/data/ParameterCatalogue.h"
@@ -106,6 +107,8 @@ bool Manager::isConfigured_{false};
 
 
 void Manager::configure(const eckit::Configuration& config) {
+    PlumeState::instance().updateState(PlumeTag::CONFIGURE);
+
     if (!Manager::isConfigured_) {
         managerConfig_         = ManagerConfig(config);
         Manager::isConfigured_ = true;
@@ -131,6 +134,8 @@ Plugin& Manager::loadPlugin(const std::string& lib, const std::string& name) {
 
 // Negotiate with all candidate plugins
 void Manager::negotiate(const Protocol& offers) {
+
+    PlumeState::instance().updateState(PlumeTag::NEGOTIATE);
 
     // before negotiation, make sure the manager has been configured
     ASSERT_MSG(isConfigured_, "Plume manager needs to be configured first!");
@@ -181,6 +186,7 @@ void Manager::negotiate(const Protocol& offers) {
 
 // Let each plugin take its own share of data (pointers)
 void Manager::feedPlugins(data::ModelData& data) {
+    PlumeState::instance().updateState(PlumeTag::FEED_PLUGINS);
 
     // check data
     Manager::checkData(data);
@@ -209,7 +215,8 @@ void Manager::feedPlugins(data::ModelData& data) {
 
 
 // Run all active plugincores
-void Manager::run() {
+void Manager::run(PlumeTag tag, std::optional<PlumeTag> parent) {
+    PlumeState::instance().updateState(tag, parent);
     for (auto& pluginHandler : PluginRegistry::instance().getActivePlugins()) {
         pluginHandler.run();
     }
@@ -218,11 +225,16 @@ void Manager::run() {
 
 // Teardown all active plugins
 void Manager::teardown() {
+    PlumeState::instance().updateState(PlumeTag::TEARDOWN);
     for (auto& pluginHandler : PluginRegistry::instance().getActivePlugins()) {
         // teardown the plugincore first
         pluginHandler.teardown();
     }
 };
+
+const PlumeState& Manager::state() {
+    return PlumeState::instance();
+}
 
 bool Manager::isPluginActivated(const std::string& name) {
     auto& pluginHandlers = PluginRegistry::instance().getActivePlugins();
@@ -260,6 +272,22 @@ bool Manager::isConfigured() {
     return Manager::isConfigured_;
 }
 
+std::string Manager::currentStateName() {
+    return PlumeState::instance().currentName();
+}
+
+std::string Manager::currentStateParent() {
+    return PlumeState::instance().currentParent();
+}
+
+std::size_t Manager::currentStateIteration() {
+    return PlumeState::instance().currentIteration();
+}
+
+std::size_t Manager::currentStateIterationRel() {
+    return PlumeState::instance().currentRelativeIteration();
+}
+
 
 void Manager::checkData(const data::ModelData& data) {
 
@@ -279,6 +307,7 @@ void Manager::checkData(const data::ModelData& data) {
 
 void Manager::reset() {
     PluginRegistry::instance().reset();
+    PlumeState::instance().reset();
     isConfigured_ = false;
     managerConfig_.reset();
 }

--- a/src/plume/Manager.h
+++ b/src/plume/Manager.h
@@ -24,6 +24,8 @@
 #include "plume/ManagerConfig.h"
 #include "plume/Plugin.h"
 #include "plume/PluginDecision.h"
+#include "plume/PlumeTag.h"
+#include "plume/PlumeState.h"
 #include "plume/data/ParameterCatalogue.h"
 #include "plume/data/ModelData.h"
 
@@ -68,13 +70,18 @@ public:
      * @brief run all active plugins
      * 
      */
-    static void run();
+    static void run(PlumeTag tag = PlumeTag::RUN, std::optional<PlumeTag> parent = std::nullopt);
 
     /**
      * @brief teardown all active plugins
      * 
      */
     static void teardown();
+
+    /**
+     * @brief state of Plume execution
+     */
+    static const PlumeState& state();
 
     /**
      * @brief check if a plugin is activated
@@ -109,6 +116,35 @@ public:
     static bool isParamRequested(const std::string& name);
 
     static bool isConfigured();
+
+    // --- Direct accessors to state from manager for convenience
+
+    /**
+     * @brief get the current state name, 
+     * e.g. "configure", "negotiate", "run", etc..
+     */
+    static std::string currentStateName();
+
+    /**
+     * @brief get state parent name
+     * 
+     * @return std::string 
+     */
+    static std::string currentStateParent();
+
+    /**
+     * @brief get the current state iteration
+     * 
+     * @return std::size_t 
+     */
+    static std::size_t currentStateIteration();
+
+    /**
+     * @brief get the current state iteration relative to the parent state
+     * 
+     * @return std::size_t 
+     */
+    static std::size_t currentStateIterationRel();
 
 private:
 

--- a/src/plume/PluginCore.cc
+++ b/src/plume/PluginCore.cc
@@ -32,6 +32,22 @@ data::ModelData& PluginCore::modelData() {
     return modelData_;
 }
 
+std::string PluginCore::currentStateName() const {
+    return PlumeState::instance().currentName();
+}
+
+std::string PluginCore::currentStateParent() const {
+    return PlumeState::instance().currentParent();
+}
+
+std::size_t PluginCore::currentStateIteration() const {
+    return PlumeState::instance().currentIteration();
+}
+
+std::size_t PluginCore::currentStateIterationRel() const {
+    return PlumeState::instance().currentRelativeIteration();
+}
+
 
 // ---------------------------------------------------------
 PluginCoreFactory::PluginCoreFactory() {}

--- a/src/plume/PluginCore.h
+++ b/src/plume/PluginCore.h
@@ -18,6 +18,7 @@
 #include "eckit/exception/Exceptions.h"
 
 #include "plume/data/ModelData.h"
+#include "plume/PlumeState.h"
 
 
 namespace plume {
@@ -87,6 +88,26 @@ public:
      * 
      */
     virtual void run() = 0;
+
+    /**
+     * @brief Name of the current manager execution state (e.g. "run", "configure", ...)
+     */
+    std::string currentStateName() const;
+
+    /**
+     * @brief Name of the parent of the current manager execution state
+     */
+    std::string currentStateParent() const;
+
+    /**
+     * @brief Absolute iteration count of the current execution state node
+     */
+    std::size_t currentStateIteration() const;
+
+    /**
+     * @brief Iteration count of the current execution state node relative to its parent's last update
+     */
+    std::size_t currentStateIterationRel() const;
 
 protected:
 

--- a/src/plume/PlumeState.cc
+++ b/src/plume/PlumeState.cc
@@ -1,0 +1,342 @@
+/*
+ * (C) Copyright 2023- ECMWF.
+ *
+ * This software is licensed under the terms of the Apache Licence Version 2.0
+ * which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * In applying this licence, ECMWF does not waive the privileges and immunities
+ * granted to it by virtue of its status as an intergovernmental organisation nor
+ * does it submit to any jurisdiction.
+ */
+#include "plume/PlumeState.h"
+#include "plume/PlumeTag.h"
+#include "plume/utils.h"
+
+
+#include <algorithm>
+#include <iostream>
+#include <sstream>
+
+#include "eckit/log/Log.h"
+#include "eckit/exception/Exceptions.h"
+
+namespace plume {
+
+
+// Return the singleton state object.
+PlumeState& PlumeState::instance() {
+    static PlumeState plumeState;
+    return plumeState;
+}
+
+// Insert or update a state node and move current pointer to it.
+void PlumeState::updateState(PlumeTag tag, std::optional<PlumeTag> parent) {
+
+    // Starting a configure step always begins a fresh execution workflow.
+    if (tag == PlumeTag::CONFIGURE && !parent) {
+        executionTree_.clear();
+        currentPath_.clear();
+    }
+
+    pathType parentPath;
+
+    // Siblings to search in: root nodes by default.
+    std::vector<TreeNode>* siblings = &executionTree_;
+
+    // If caller specified a parent tag, resolve the latest matching node.
+    std::optional<PlumeTag> parentName;
+    if (parent) {
+
+        const std::size_t parentMatches = countNodesByName(*parent);
+        if (parentMatches > 1) {
+            std::string errorMsg = "Ambiguous parent tag in execution tree: " + plumeTagToString(*parent) +
+                                   ". Use unique parent tags in client code.";
+            throw eckit::BadParameter(errorMsg, Here());
+        }
+
+        // Find path of latest node named 'parent'.
+        if (!findLatestNodeByName(*parent, parentPath)) {
+            // Parent was requested but does not exist.
+            std::string errorMsg = "Parent not found in execution tree: " + plumeTagToString(*parent);
+            throw eckit::BadParameter(errorMsg, Here());
+        }
+
+        // Resolve (and check) node pointer from computed path.
+        TreeNode* parentNode = findTreeNodeByPath(parentPath);
+        if (!parentNode) {
+            std::string errorMsg = "Parent path not found in execution tree for parent: " + plumeTagToString(*parent);
+            throw eckit::BadParameter(errorMsg, Here());
+        }
+
+        parentName = parentNode->name; // Use resolved parent node metadata
+        siblings = &parentNode->children; // Children become target sibling list
+    }
+
+    // Find existing node in sibling set matching both tag and parent name.
+    auto treeNodeIt = std::find_if(siblings->begin(), siblings->end(), [&tag, &parentName](const TreeNode& node) {
+        return node.name == tag && node.parent == parentName;
+    });
+
+    // Index of the node we will end up selecting/creating.
+    std::size_t nodeIndex = 0;
+    // Existing node case: increment counters.
+    if (treeNodeIt != siblings->end()) {
+        treeNodeIt->iteration += 1;
+        treeNodeIt->iteration_relative += 1;
+        // Parent iteration moved, so each direct child starts a new relative epoch.
+        for (auto& child : treeNodeIt->children) {
+            child.iteration_relative = 0;
+        }
+        // Capture index of existing node.
+        nodeIndex = static_cast<std::size_t>(std::distance(siblings->begin(), treeNodeIt));
+    }
+    // New node case: insert with initial counters set to 1.
+    else {
+        // Insert node with resolved parent name and empty child list.
+        siblings->push_back({tag, 1, 1, parentName, {}});
+        // New node is at the back.
+        nodeIndex = siblings->size() - 1;
+    }
+
+    // Set Current path (parent path first, then append selected child index).
+    currentPath_ = parentPath;
+    currentPath_.push_back(nodeIndex);
+
+    // Cache current node name for quick access.
+    current_ = tag;
+    // Mark serialized state snapshot dirty; it will be rebuilt lazily on read.
+    configDirty_ = true;
+}
+
+// Fully clear runtime state and publish empty config.
+void PlumeState::reset() {
+    executionTree_.clear();
+    current_.reset();
+    currentPath_.clear();
+    configDirty_ = true;
+}
+
+// Return a copy of the exported configuration snapshot.
+eckit::LocalConfiguration PlumeState::getConfig() const {
+    if (configDirty_) {
+        updateConfig();
+    }
+    return config_;
+}
+
+// Return the current node name (empty if no current node).
+std::string PlumeState::currentName() const {
+    return current_ ? plumeTagToString(*current_) : "";
+}
+
+// Return current node parent name (empty for root/no-current).
+std::string PlumeState::currentParent() const {
+    const TreeNode* node = currentNode();
+    // If current exists return parent name, otherwise empty string.
+    return (node && node->parent) ? plumeTagToString(*node->parent) : "";
+}
+
+// Return absolute iteration count for current node.
+std::size_t PlumeState::currentIteration() const {
+    const TreeNode* node = currentNode();
+    // If current exists return absolute iteration, otherwise 0.
+    return node ? node->iteration : 0;
+}
+
+// Return iteration count relative to parent epoch for current node.
+std::size_t PlumeState::currentRelativeIteration() const {
+    const TreeNode* node = currentNode();
+    // If current exists return relative iteration, otherwise 0.
+    return node ? node->iteration_relative : 0;
+}
+
+// Stream state as JSON-like text.
+std::ostream& operator<<(std::ostream& os, const PlumeState& state) {
+    auto cfg = state.getConfig();
+    configToJson(cfg, os, 2);
+    return os;
+}
+
+
+// ----------- private methods -----------
+
+// Resolve mutable node pointer from index path.
+PlumeState::TreeNode* PlumeState::findTreeNodeByPath(const pathType& path) {
+    // Empty path means "no node".
+    if (path.empty()) {
+        return nullptr;
+    }
+
+    // Start traversal at root sibling vector.
+    std::vector<TreeNode>* siblings = &executionTree_;
+    // Track current node as we descend.
+    TreeNode* currentNode           = nullptr;
+
+    // Walk each index in the path.
+    for (const auto& idx : path) {
+        // Guard against invalid index.
+        if (idx >= siblings->size()) {
+            return nullptr;
+        }
+
+        currentNode = &(*siblings)[idx]; // Step into selected sibling.
+        siblings = &currentNode->children; // Next indices refer to its children.
+    }
+
+    // Return resolved node pointer.
+    return currentNode;
+}
+
+// Resolve const node pointer from index path.
+const PlumeState::TreeNode* PlumeState::findTreeNodeByPath(const pathType& path) const {
+    // Empty path means "no node".
+    if (path.empty()) {
+        return nullptr;
+    }
+
+    // Start traversal at root sibling vector.
+    const std::vector<TreeNode>* siblings = &executionTree_;
+    // Track current node as we descend.
+    const TreeNode* currentNode = nullptr;
+
+    // Walk each index in the path.
+    for (const auto& idx : path) {
+        // Guard against invalid index.
+        if (idx >= siblings->size()) {
+            return nullptr;
+        }
+
+        // Step into selected sibling.
+        currentNode = &(*siblings)[idx];
+        // Next indices refer to its children.
+        siblings = &currentNode->children;
+    }
+
+    // Return resolved node pointer.
+    return currentNode;
+}
+
+// Find path of the latest node matching a name using depth-first traversal.
+bool PlumeState::findLatestNodeByName(PlumeTag name, pathType& path) const {
+
+    pathType prefix; // Current DFS traversal prefix path.
+    pathType foundPath; // Last matching path found by DFS.
+    bool found = false; // "found anything" flag shared with recursion.
+
+    // Recursive DFS over full tree.
+    findLatestNodeByNameRec(executionTree_, name, prefix, foundPath, found);
+    // If at least one match was found, publish the latest path.
+    if (found) {
+        path = foundPath;
+    }
+    // Return whether a match exists.
+    return found;
+}
+
+std::size_t PlumeState::countNodesByName(PlumeTag name) const {
+    std::size_t count = 0;
+    countNodesByNameRec(executionTree_, name, count);
+    return count;
+}
+
+void PlumeState::countNodesByNameRec(const std::vector<TreeNode>& nodes,
+                                     PlumeTag name,
+                                     std::size_t& count) {
+    for (const auto& node : nodes) {
+        if (node.name == name) {
+            ++count;
+        }
+        countNodesByNameRec(node.children, name, count);
+    }
+}
+
+// DFS helper: updates foundPath whenever it visits a matching node.
+bool PlumeState::findLatestNodeByNameRec(const std::vector<TreeNode>& nodes,
+                                         PlumeTag name,
+                                         std::vector<std::size_t>& prefix,
+                                         std::vector<std::size_t>& foundPath,
+                                         bool& found) {
+    // Iterate siblings in order.
+    for (std::size_t i = 0; i < nodes.size(); ++i) {
+        // Enter node i by extending prefix.
+        prefix.push_back(i);
+
+        // If node name matches target, remember this path as latest so far.
+        if (nodes[i].name == name) {
+            foundPath = prefix;
+            found = true;
+        }
+
+        // Recurse into children (depth-first).
+        findLatestNodeByNameRec(nodes[i].children, name, prefix, foundPath, found);
+        // Leave node i and restore prefix for next sibling.
+        prefix.pop_back();
+    }
+
+    // Return whether any match has been seen in this DFS.
+    return found;
+}
+
+// Resolve pointer to current node from currentPath_.
+const PlumeState::TreeNode* PlumeState::currentNode() const {
+    return findTreeNodeByPath(currentPath_);
+}
+
+// Convert one TreeNode (recursively) into LocalConfiguration.
+eckit::LocalConfiguration PlumeState::treeNodeToConfig(const TreeNode& node) {
+
+    eckit::LocalConfiguration nodeConfig;
+
+    nodeConfig.set("name", plumeTagToString(node.name));
+    nodeConfig.set("iteration", static_cast<size_t>(node.iteration));
+    nodeConfig.set("iteration_relative", static_cast<size_t>(node.iteration_relative));
+
+    // Store parent field (empty string for root nodes).
+    if (node.parent) {
+        nodeConfig.set("parent", plumeTagToString(*node.parent));
+    } else {
+        nodeConfig.set("parent", "");
+    }
+
+    // Recursively serialize children if present.
+    if (!node.children.empty()) {
+        std::vector<eckit::LocalConfiguration> childrenConfig;
+        childrenConfig.reserve(node.children.size());
+        for (const auto& child : node.children) {
+            childrenConfig.push_back(treeNodeToConfig(child));
+        }
+        nodeConfig.set("children", childrenConfig);
+    }
+
+    // Return serialized node.
+    return nodeConfig;
+}
+
+
+// Rebuild exported LocalConfiguration snapshot from in-memory tree.
+void PlumeState::updateConfig() const {
+
+    eckit::LocalConfiguration state;
+    std::vector<eckit::LocalConfiguration> treeConfig;
+    treeConfig.reserve(executionTree_.size());
+
+    // Recursively serialize each node.
+    for (const auto& node : executionTree_) {
+        treeConfig.push_back(treeNodeToConfig(node));
+    }
+
+    state.set("execution_tree", treeConfig);
+    state.set("current", current_ ? plumeTagToString(*current_) : "");
+
+    // Optionally publish full current node payload.
+    const TreeNode* node = currentNode();
+    if (node) {
+        state.set("current_node", treeNodeToConfig(*node));
+    }
+
+    // Atomically replace cached config snapshot.
+    config_ = state;
+    configDirty_ = false;
+}
+
+}  // namespace plume

--- a/src/plume/PlumeState.h
+++ b/src/plume/PlumeState.h
@@ -1,0 +1,125 @@
+/*
+ * (C) Copyright 2023- ECMWF.
+ *
+ * This software is licensed under the terms of the Apache Licence Version 2.0
+ * which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * In applying this licence, ECMWF does not waive the privileges and immunities
+ * granted to it by virtue of its status as an intergovernmental organisation nor
+ * does it submit to any jurisdiction.
+ */
+#pragma once
+
+#include <cstddef>
+#include <iosfwd>
+#include <optional>
+#include <string>
+#include <vector>
+
+#include "eckit/config/LocalConfiguration.h"
+#include "plume/PlumeTag.h"
+
+
+namespace plume {
+
+class PlumeState {
+
+    // Type alias for a path in the execution tree (vector of child indices)
+    using pathType = std::vector<std::size_t>;
+
+public:
+    static PlumeState& instance();
+
+    /**
+     * @brief Insert or update a state node and move current pointer to it.
+     * For root-level state transitions (e.g. configure/negotiate/feed/teardown), call with parent unset.
+     * For nested run transitions, pass the optional parent tag.
+     * 
+     * @param tag Current state tag.
+     * @param parent Optional parent tag for nested run states.
+     */
+    void updateState(PlumeTag tag, std::optional<PlumeTag> parent = std::nullopt);
+
+    void reset();
+
+    eckit::LocalConfiguration getConfig() const;
+
+    /**
+     * @brief Getters for current node ("current" is here intended as "before next update")
+     */
+    std::string currentName() const;
+
+    /**
+     * @brief Getters for current node parent name
+     */
+    std::string currentParent() const;
+
+    /**
+     * @brief Getters for current node iteration count (absolute)
+     */
+    std::size_t currentIteration() const;
+
+    /**
+     * @brief Getters for current node iteration count relative to parent
+     */
+    std::size_t currentRelativeIteration() const;
+
+    friend std::ostream& operator<<(std::ostream& os, const PlumeState& state);
+    
+private:
+
+    struct TreeNode {
+        PlumeTag name;
+        std::size_t iteration{1};
+        std::size_t iteration_relative{1};  ///< iteration count since parent's last update
+        std::optional<PlumeTag> parent;
+        std::vector<TreeNode> children;
+    };
+
+    // find a node in the execution tree by its path (vector of indices)
+    // used to update the current node after each updateState call
+    TreeNode* findTreeNodeByPath(const std::vector<std::size_t>& path);
+
+    // const version of findTreeNodeByPath
+    const TreeNode* findTreeNodeByPath(const pathType& path) const;
+
+    // find the latest node with the given name in the execution tree,
+    // (used to implement updateState when parent is specified)
+    bool findLatestNodeByName(PlumeTag name, pathType& path) const;
+
+    // recursive helper for findLatestNodeByName
+    static bool findLatestNodeByNameRec(const std::vector<TreeNode>& nodes,
+                                        PlumeTag name,
+                                        pathType& prefix,
+                                        pathType& foundPath,
+                                        bool& found);
+
+    // count how many nodes in the execution tree have a given name
+    std::size_t countNodesByName(PlumeTag name) const;
+
+    // recursive helper for countNodesByName
+    static void countNodesByNameRec(const std::vector<TreeNode>& nodes,
+                                    PlumeTag name,
+                                    std::size_t& count);
+
+    // Return pointer to current node, or nullptr if no current node.
+    const TreeNode* currentNode() const;
+
+    // Convert one TreeNode (recursively) into LocalConfiguration.
+    static eckit::LocalConfiguration treeNodeToConfig(const TreeNode& node);
+
+    // Update the exported configuration from the current execution tree and current node.
+    // Marked as const since it does not modify the logical state, but only the cached configuration (mutable).
+    void updateConfig() const;
+
+    std::vector<TreeNode> executionTree_;
+    std::optional<PlumeTag> current_;
+    pathType currentPath_;
+    mutable eckit::LocalConfiguration config_;
+    mutable bool configDirty_{true};
+
+};
+
+std::ostream& operator<<(std::ostream& os, const PlumeState& state);
+
+}  // namespace plume

--- a/src/plume/PlumeTag.cc
+++ b/src/plume/PlumeTag.cc
@@ -1,0 +1,66 @@
+/*
+ * (C) Copyright 2023- ECMWF.
+ *
+ * This software is licensed under the terms of the Apache Licence Version 2.0
+ * which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * In applying this licence, ECMWF does not waive the privileges and immunities
+ * granted to it by virtue of its status as an intergovernmental organisation nor
+ * does it submit to any jurisdiction.
+ */
+
+#include "plume/PlumeTag.h"
+
+#include "eckit/exception/Exceptions.h"
+
+namespace plume {
+
+namespace {
+
+// convenience struct to define the mapping between enum values and tag names
+struct TagEntry {
+    PlumeTag tag;
+    const char* name;
+};
+
+constexpr TagEntry kTagEntries[] = {
+#define PLUME_TAG(tag_id, tag_name) {PlumeTag::tag_id, tag_name},
+#include "TagDefinitions.def"
+#undef PLUME_TAG
+};
+
+std::string validTagsMessage() {
+    std::string message = "Valid tags are: ";
+    for (std::size_t i = 0; i < (sizeof(kTagEntries) / sizeof(kTagEntries[0])); ++i) {
+        if (i > 0) {
+            message += ", ";
+        }
+        message += kTagEntries[i].name;
+    }
+    message += ".";
+    return message;
+}
+
+}  // namespace
+
+std::string plumeTagToString(PlumeTag tag) {
+    for (const auto& entry : kTagEntries) {
+        if (entry.tag == tag) {
+            return entry.name;
+        }
+    }
+
+    throw eckit::BadParameter("Unsupported plume tag enum value.", Here());
+}
+
+PlumeTag plumeTagFromString(const std::string& tag) {
+    for (const auto& entry : kTagEntries) {
+        if (entry.name == tag) {
+            return entry.tag;
+        }
+    }
+
+    throw eckit::BadParameter("Invalid plume tag: '" + tag + "'. " + validTagsMessage(), Here());
+}
+
+}  // namespace plume

--- a/src/plume/PlumeTag.h
+++ b/src/plume/PlumeTag.h
@@ -1,0 +1,27 @@
+/*
+ * (C) Copyright 2023- ECMWF.
+ *
+ * This software is licensed under the terms of the Apache Licence Version 2.0
+ * which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * In applying this licence, ECMWF does not waive the privileges and immunities
+ * granted to it by virtue of its status as an intergovernmental organisation nor
+ * does it submit to any jurisdiction.
+ */
+#pragma once
+
+#include <string>
+
+namespace plume {
+
+// Define PlumeTag enum class from TagDefinitions.def
+enum class PlumeTag {
+#define PLUME_TAG(tag_id, tag_name) tag_id, // just list tag_id's here to define the enum entries
+#include "TagDefinitions.def"
+#undef PLUME_TAG
+};
+
+std::string plumeTagToString(PlumeTag tag);
+PlumeTag plumeTagFromString(const std::string& tag);
+
+}  // namespace plume

--- a/src/plume/TagDefinitions.def
+++ b/src/plume/TagDefinitions.def
@@ -1,0 +1,35 @@
+/*
+ * (C) Copyright 2023- ECMWF.
+ *
+ * This software is licensed under the terms of the Apache Licence Version 2.0
+ * which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * In applying this licence, ECMWF does not waive the privileges and immunities
+ * granted to it by virtue of its status as an intergovernmental organisation nor
+ * does it submit to any jurisdiction.
+ */
+
+// This list defines the supported Plume tags, used to 
+// decorate the execution of Plume manager methods.
+// It represents the unique source of truth for defining tags
+// It is used for C and Fortran API as well.
+// TODO: still to discuss if/how to have only generic tags
+
+PLUME_TAG(CONFIGURE, "configure")
+PLUME_TAG(NEGOTIATE, "negotiate")
+PLUME_TAG(FEED_PLUGINS, "feed_plugins")
+PLUME_TAG(RUN, "run")
+PLUME_TAG(TEARDOWN, "teardown")
+PLUME_TAG(RUN_LVL1, "run_lvl1")
+PLUME_TAG(RUN_LVL2, "run_lvl2")
+PLUME_TAG(RUN_LVL3, "run_lvl3")
+PLUME_TAG(RUN_LVL4, "run_lvl4")
+PLUME_TAG(RUN_LVL5, "run_lvl5")
+PLUME_TAG(RUN_LVL6, "run_lvl6")
+PLUME_TAG(RUN_LVL7, "run_lvl7")
+PLUME_TAG(RUN_LVL8, "run_lvl8")
+PLUME_TAG(RUN_LVL9, "run_lvl9")
+PLUME_TAG(RUN_LVL10, "run_lvl10")
+PLUME_TAG(RUN_BEFORE_PHYSICS, "run_before_physics")
+PLUME_TAG(RUN_AFTER_PHYSICS, "run_after_physics")
+PLUME_TAG(RUN_WAVE_MODEL, "run_wave_model")

--- a/src/plume/api/CMakeLists.txt
+++ b/src/plume/api/CMakeLists.txt
@@ -18,6 +18,7 @@ ecbuild_add_library(
         ${INSTALL_INCLUDE_DIR}/plume
 
     SOURCES
+        ${CMAKE_CURRENT_SOURCE_DIR}/../TagDefinitions.def
         plume.h
         plume.cc
 
@@ -36,6 +37,25 @@ ecbuild_add_library(
 )
 
 
+set(PLUME_TAG_DEFINITIONS ${CMAKE_CURRENT_SOURCE_DIR}/../TagDefinitions.def)
+set(PLUME_FORTRAN_TAGS_MODULE ${CMAKE_CURRENT_BINARY_DIR}/plume_tags.F90)
+
+add_custom_command(
+    OUTPUT ${PLUME_FORTRAN_TAGS_MODULE}
+    COMMAND ${CMAKE_COMMAND}
+        -DINPUT=${PLUME_TAG_DEFINITIONS}
+        -DOUTPUT=${PLUME_FORTRAN_TAGS_MODULE}
+        -P ${PROJECT_SOURCE_DIR}/cmake/generate_plume_tags_fortran.cmake
+    DEPENDS
+        ${PLUME_TAG_DEFINITIONS}
+        ${PROJECT_SOURCE_DIR}/cmake/generate_plume_tags_fortran.cmake
+    COMMENT "Generating Fortran plume tag constants module"
+    VERBATIM
+)
+
+add_custom_target(plume_generate_fortran_tags DEPENDS ${PLUME_FORTRAN_TAGS_MODULE})
+
+
 # plume Fortran-API
 ecbuild_add_library(
 
@@ -47,8 +67,10 @@ ecbuild_add_library(
         ${INSTALL_INCLUDE_DIR}/plume
 
     SOURCES
+        ${PLUME_FORTRAN_TAGS_MODULE}
         plume.F90
         plume_lib.F90
+        plume_state.F90
         plume_utils.F90
         plume_data.F90
         plume_manager.F90
@@ -68,6 +90,8 @@ ecbuild_add_library(
         atlas_f
         plume
 )
+
+    add_dependencies(plume_f plume_generate_fortran_tags)
 
 install( DIRECTORY ${CMAKE_Fortran_MODULE_DIRECTORY}/${CMAKE_CFG_INTDIR}
          DESTINATION module/plume

--- a/src/plume/api/plume.F90
+++ b/src/plume/api/plume.F90
@@ -10,6 +10,10 @@ module plume_module
 
 use plume_lib_module, only : plume_initialise, &
                              plume_finalise
+use plume_state_module, only : plume_state_current_name, &
+                               plume_state_current_parent, &
+                               plume_state_current_iteration, &
+                               plume_state_current_iteration_rel
 
 use plume_data_module, only : plume_data
 use plume_manager_module, only : plume_manager
@@ -29,9 +33,17 @@ integer, public, parameter :: PLUME_ERROR_UNKNOWN_EXCEPTION = 2
 public :: plume_check
 public :: plume_error_string
 
+! Plume lib API
 public :: plume_initialise
 public :: plume_finalise
 
+! Plume state API
+public :: plume_state_current_name
+public :: plume_state_current_parent
+public :: plume_state_current_iteration
+public :: plume_state_current_iteration_rel
+
+! Plume structures
 public :: plume_data
 public :: plume_manager
 public :: plume_protocol

--- a/src/plume/api/plume.cc
+++ b/src/plume/api/plume.cc
@@ -11,6 +11,8 @@
 #include <functional>
 #include <iostream>
 #include <map>
+#include <optional>
+#include <string>
 #include <vector>
 
 #include "eckit/config/YAMLConfiguration.h"
@@ -26,6 +28,8 @@
 
 #include "plume.h"
 #include "plume/Manager.h"
+#include "plume/PlumeTag.h"
+#include "plume/PlumeState.h"
 #include "plume/data/ParameterCatalogue.h"
 #include "plume/data/ModelData.h"
 
@@ -35,6 +39,20 @@ static std::string g_current_error_str;
 static plume_failure_handler_t g_failure_handler = nullptr;
 static void* g_failure_handler_context           = nullptr;
 static bool plume_initialised                    = false;
+
+namespace {
+
+plume::PlumeTag plumeTagFromId(plume_tag_id_t tag_id) {
+    switch (tag_id) {
+#define PLUME_TAG(tag_id, tag_name) case PLUME_TAG_ID_##tag_id: return plume::PlumeTag::tag_id;
+#include "plume/TagDefinitions.def"
+#undef PLUME_TAG
+        default:
+            throw eckit::BadParameter("Invalid plume tag id: " + std::to_string(static_cast<int>(tag_id)), Here());
+    }
+}
+
+}  // namespace
 
 
 /** Returns the error string */
@@ -48,6 +66,16 @@ const char* plume_error_string(int err) {
         default:
             return "<unknown>";
     };
+}
+
+const char* plume_tag_name(plume_tag_id_t tag_id) {
+    switch (tag_id) {
+#define PLUME_TAG(tag_id, tag_name) case PLUME_TAG_ID_##tag_id: return tag_name;
+#include "plume/TagDefinitions.def"
+#undef PLUME_TAG
+        default:
+            return nullptr;
+    }
 }
 
 int innerWrapFn(std::function<int()> f) {
@@ -159,6 +187,35 @@ int plume_finalise() {
         else {
             plume_initialised = false;
         }
+    });
+}
+// --------------------------------------------------------------------------------------
+
+
+// ------------------------------------ PLUME state --------------------------------------
+int plume_state_current_name(char** state_name) {
+    return wrapApiFunction([&state_name] {
+        std::string stateName = plume::PlumeState::instance().currentName();
+        *state_name = strcpy(new char[stateName.length() + 1], stateName.c_str());
+    });
+}
+
+int plume_state_current_parent(char** state_parent) {
+    return wrapApiFunction([&state_parent] {
+        std::string stateParent = plume::PlumeState::instance().currentParent();
+        *state_parent = strcpy(new char[stateParent.length() + 1], stateParent.c_str());
+    });
+}
+
+int plume_state_current_iteration(int64_t* iteration) {
+    return wrapApiFunction([&iteration] {
+        *iteration = static_cast<int64_t>(plume::PlumeState::instance().currentIteration());
+    });
+}
+
+int plume_state_current_iteration_rel(int64_t* iteration_rel) {
+    return wrapApiFunction([&iteration_rel] {
+        *iteration_rel = static_cast<int64_t>(plume::PlumeState::instance().currentRelativeIteration());
     });
 }
 // --------------------------------------------------------------------------------------
@@ -328,12 +385,53 @@ int plume_manager_is_plugin_activated(plume_manager_handle_t* h, const char* nam
     });
 }
 
-int plume_manager_run(plume_manager_handle_t* h) {
-    return wrapApiFunction([h] {
+int plume_manager_current_state_name(plume_manager_handle_t* h, char** state_name) {
+    return wrapApiFunction([h, &state_name] {
         ASSERT(h);
         ASSERT((h)->impl_);
 
-        h->impl_->run();
+        std::string stateName = h->impl_->currentStateName();
+        *state_name = strcpy(new char[stateName.length() + 1], stateName.c_str());
+    });
+}
+
+int plume_manager_current_state_parent(plume_manager_handle_t* h, char** state_parent) {
+    return wrapApiFunction([h, &state_parent] {
+        ASSERT(h);
+        ASSERT((h)->impl_);
+
+        std::string stateParent = h->impl_->currentStateParent();
+        *state_parent = strcpy(new char[stateParent.length() + 1], stateParent.c_str());
+    });
+}
+
+int plume_manager_current_state_iteration(plume_manager_handle_t* h, int64_t* iteration) {
+    return wrapApiFunction([h, &iteration] {
+        ASSERT(h);
+        ASSERT((h)->impl_);
+
+        *iteration = static_cast<int64_t>(h->impl_->currentStateIteration());
+    });
+}
+
+int plume_manager_current_state_iteration_rel(plume_manager_handle_t* h, int64_t* iteration_rel) {
+    return wrapApiFunction([h, &iteration_rel] {
+        ASSERT(h);
+        ASSERT((h)->impl_);
+
+        *iteration_rel = static_cast<int64_t>(h->impl_->currentStateIterationRel());
+    });
+}
+
+int plume_manager_run(plume_manager_handle_t* h, plume_tag_id_t tag_id, bool has_parent, plume_tag_id_t parent_id) {
+    return wrapApiFunction([h, tag_id, has_parent, parent_id] {
+        ASSERT(h);
+        ASSERT((h)->impl_);
+
+        const plume::PlumeTag tag_enum = plumeTagFromId(tag_id);
+        const std::optional<plume::PlumeTag> parent_enum = has_parent ? std::optional<plume::PlumeTag>(plumeTagFromId(parent_id))
+                                                                       : std::nullopt;
+        h->impl_->run(tag_enum, parent_enum);
     });
 }
 
@@ -518,6 +616,15 @@ int plume_data_set_updated(plume_data_handle_t* h, const int count, const char**
         params.push_back(names[i]);
     }
     return wrapApiFunction([h, params] {h->impl_->setUpdated(params); });
+}
+
+// delete a C-string allocated by Plume API functions
+int plume_delete_string(char* str) {
+    return wrapApiFunction([str] {
+        if (str) {
+            delete[] str;
+        }
+    });
 }
 
 // --------------------------------------------------------------------------------------

--- a/src/plume/api/plume.h
+++ b/src/plume/api/plume.h
@@ -15,8 +15,25 @@ extern "C" {
 #endif
 
 #include <stdbool.h>
+#include <stdint.h>
 
 /* Plume C-interface */
+
+/* --- Plume tags (shared C/C++/Fortran definitions) --- */
+typedef enum plume_tag_id_t {
+#define PLUME_TAG(tag_id, tag_name) PLUME_TAG_ID_##tag_id,
+#include "plume/TagDefinitions.def"
+#undef PLUME_TAG
+    PLUME_TAG_ID_COUNT
+} plume_tag_id_t;
+
+/**
+ * @brief Get canonical tag name for tag ID
+ *
+ * @param tag_id Tag identifier
+ * @return Canonical tag name (e.g. "run_lvl1") or NULL for invalid IDs
+ */
+const char* plume_tag_name(plume_tag_id_t tag_id);
 
 
 /* Return Codes */
@@ -93,6 +110,41 @@ int plume_initialise(int argc, char** argv);
 int plume_finalise();
 
 
+/* --- Plume State (singleton) --- */
+
+/**
+ * @brief Get current state name from the global Plume state singleton
+ *
+ * @param state_name Current state name (allocated C-string)
+ * @return Error code
+ */
+int plume_state_current_name(char** state_name);
+
+/**
+ * @brief Get current parent state name from the global Plume state singleton
+ *
+ * @param state_parent Current parent state name (allocated C-string)
+ * @return Error code
+ */
+int plume_state_current_parent(char** state_parent);
+
+/**
+ * @brief Get current absolute iteration from the global Plume state singleton
+ *
+ * @param iteration Current absolute iteration
+ * @return Error code
+ */
+int plume_state_current_iteration(int64_t* iteration);
+
+/**
+ * @brief Get current relative iteration from the global Plume state singleton
+ *
+ * @param iteration_rel Current relative iteration
+ * @return Error code
+ */
+int plume_state_current_iteration_rel(int64_t* iteration_rel);
+
+
 /* --- Plume Protocol --- */
 int plume_protocol_create_handle(plume_protocol_handle_t** h);
 int plume_protocol_offer_int(plume_protocol_handle_t* h, const char* name, const char* avail, const char* comment);
@@ -148,8 +200,7 @@ int plume_manager_configure_from_string(plume_manager_handle_t* h, const char* c
  * @brief Load all the plugins
  *
  * @param h Handle
- * @param config_path Path to manager configuration file
- * @param field_catalogue catalogue of available fields
+ * @param p Protocol handle
  * @return Error code
  */
 int plume_manager_negotiate(plume_manager_handle_t* h, plume_protocol_handle_t* p);
@@ -202,17 +253,56 @@ int plume_manager_is_param_requested(plume_manager_handle_t* h, const char* name
 int plume_manager_is_plugin_activated(plume_manager_handle_t* h, const char* name, bool* activated);
 
 /**
- * @brief Run all plugins
+ * @brief Get current manager state name
  *
  * @param h Handle
+ * @param state_name Current state name (allocated C-string)
  * @return Error code
  */
-int plume_manager_run(plume_manager_handle_t* h);
+int plume_manager_current_state_name(plume_manager_handle_t* h, char** state_name);
+
+/**
+ * @brief Get current manager parent state name
+ *
+ * @param h Handle
+ * @param state_parent Current parent state name (allocated C-string)
+ * @return Error code
+ */
+int plume_manager_current_state_parent(plume_manager_handle_t* h, char** state_parent);
+
+/**
+ * @brief Get current manager state absolute iteration
+ *
+ * @param h Handle
+ * @param iteration Current state absolute iteration
+ * @return Error code
+ */
+int plume_manager_current_state_iteration(plume_manager_handle_t* h, int64_t* iteration);
+
+/**
+ * @brief Get current manager state iteration relative to parent
+ *
+ * @param h Handle
+ * @param iteration_rel Current state relative iteration
+ * @return Error code
+ */
+int plume_manager_current_state_iteration_rel(plume_manager_handle_t* h, int64_t* iteration_rel);
+
+/**
+ * @brief Run all plugins using typed tag IDs
+ *
+ * @param h Handle
+ * @param tag_id Tag ID for this run step
+ * @param has_parent Whether parent_id should be used
+ * @param parent_id Parent tag ID for nested runs (ignored when has_parent is false)
+ * @return Error code
+ */
+int plume_manager_run(plume_manager_handle_t* h, plume_tag_id_t tag_id, bool has_parent, plume_tag_id_t parent_id);
 
 /**
  * @brief Teardown plugins
  * 
- * @param h 
+ * @param h Handle
  * @return int 
  */
 int plume_manager_teardown(plume_manager_handle_t* h);
@@ -224,8 +314,6 @@ int plume_manager_teardown(plume_manager_handle_t* h);
  * @return Error code
  */
 int plume_manager_delete_handle(plume_manager_handle_t* h);
-
-
 
 
 /* --- Plume Data --- */
@@ -456,6 +544,17 @@ int plume_data_print(plume_data_handle_t* h);
  * @return Error code
  */
 int plume_data_set_updated(plume_data_handle_t* h, const int count, const char** names);
+
+/**
+ * @brief Delete a C-string allocated by Plume API functions
+ *
+ * @param str Pointer to C-string allocated by functions like plume_manager_current_state_name
+ * @return Error code
+ */
+int plume_delete_string(char* str);
+
+
+
 
 
 #if defined(__cplusplus)

--- a/src/plume/api/plume_manager.F90
+++ b/src/plume/api/plume_manager.F90
@@ -15,6 +15,8 @@ use fckit_c_interop_module, only : c_str
 use plume_utils_module, only : fortranise_cstr
 use plume_data_module, only : plume_data
 use plume_protocol_module, only : plume_protocol
+use plume_tags_module, only : PLUME_TAG_RUN
+use plume_utils_module, only : plume_delete_string
 
 implicit none
 private
@@ -35,6 +37,10 @@ contains
     procedure :: active_fields_catalogue => plume_manager_active_fields_catalogue
     procedure :: is_param_requested => plume_manager_is_param_requested
     procedure :: is_plugin_activated => plume_manager_is_plugin_activated
+    procedure :: current_state_name => plume_manager_current_state_name
+    procedure :: current_state_parent => plume_manager_current_state_parent
+    procedure :: current_state_iteration => plume_manager_current_state_iteration
+    procedure :: current_state_iteration_rel => plume_manager_current_state_iteration_rel
 
     procedure :: feed_plugins => plume_manager_feed_plugins
     procedure :: run => plume_manager_run
@@ -70,7 +76,7 @@ end function
 
 function plume_manager_negotiate_interf(handle_impl, proto_handle_impl) result(err) &
     & bind(C,name="plume_manager_negotiate")
-    use iso_c_binding, only: c_int, c_ptr
+    use iso_c_binding, only: c_int, c_ptr, c_char
     type(c_ptr), intent(in), value :: handle_impl
     type(c_ptr), intent(in), value :: proto_handle_impl
     integer(c_int) :: err
@@ -110,24 +116,59 @@ function plume_manager_is_plugin_activated_interf(handle_impl, name, is_plugin) 
     integer :: err
 end function
 
+function plume_manager_current_state_name_interf(handle_impl, state_name) result(err) &
+    & bind(C, name="plume_manager_current_state_name")
+    use iso_c_binding, only: c_ptr, c_int
+    type(c_ptr), intent(in), value :: handle_impl
+    type(c_ptr), intent(inout) :: state_name
+    integer(c_int) :: err
+end function
+
+function plume_manager_current_state_parent_interf(handle_impl, state_parent) result(err) &
+    & bind(C, name="plume_manager_current_state_parent")
+    use iso_c_binding, only: c_ptr, c_int
+    type(c_ptr), intent(in), value :: handle_impl
+    type(c_ptr), intent(inout) :: state_parent
+    integer(c_int) :: err
+end function
+
+function plume_manager_current_state_iteration_interf(handle_impl, iteration) result(err) &
+    & bind(C, name="plume_manager_current_state_iteration")
+    use iso_c_binding, only: c_ptr, c_int, c_int64_t
+    type(c_ptr), intent(in), value :: handle_impl
+    integer(c_int64_t), intent(inout) :: iteration
+    integer(c_int) :: err
+end function
+
+function plume_manager_current_state_iteration_rel_interf(handle_impl, iteration_rel) result(err) &
+    & bind(C, name="plume_manager_current_state_iteration_rel")
+    use iso_c_binding, only: c_ptr, c_int, c_int64_t
+    type(c_ptr), intent(in), value :: handle_impl
+    integer(c_int64_t), intent(inout) :: iteration_rel
+    integer(c_int) :: err
+end function
+
 function plume_manager_feed_plugins_interf(handle_impl, fdata) result(err) &
   & bind(C,name="plume_manager_feed_plugins")
-  use iso_c_binding, only: c_int, c_ptr
+  use iso_c_binding, only: c_int, c_ptr, c_char
   type(c_ptr), intent(in), value :: handle_impl
   type(c_ptr), intent(in), value :: fdata
   integer(c_int) :: err
 end function
 
-function plume_manager_run_interf(handle_impl) result(err) &
+function plume_manager_run_interf(handle_impl, tag_id, has_parent, parent_id) result(err) &
     & bind(C,name="plume_manager_run")
-    use iso_c_binding, only: c_int, c_ptr
+    use iso_c_binding, only: c_int, c_ptr, c_bool
     type(c_ptr), intent(in), value :: handle_impl
+    integer(c_int), intent(in), value :: tag_id
+    logical(c_bool), intent(in), value :: has_parent
+    integer(c_int), intent(in), value :: parent_id
     integer(c_int) :: err
 end function
 
 function plume_manager_teardown_interf(handle_impl) result(err) &
     & bind(C,name="plume_manager_teardown")
-    use iso_c_binding, only: c_int, c_ptr
+    use iso_c_binding, only: c_int, c_ptr, c_char
     type(c_ptr), intent(in), value :: handle_impl
     integer(c_int) :: err
 end function
@@ -152,7 +193,7 @@ function plume_manager_create_handle(handle) result(err)
 end function
 
 function plume_manager_configure(handle, config_str) result(err)
-    use iso_c_binding, only: c_null_char, c_char
+    use iso_c_binding, only: c_char
     class(plume_manager), intent(inout) :: handle
     character(kind=c_char,len=*), intent(in) :: config_str
     integer :: err
@@ -160,7 +201,7 @@ function plume_manager_configure(handle, config_str) result(err)
 end function
 
 function plume_manager_configure_from_string(handle, config_str) result(err)
-    use iso_c_binding, only: c_null_char, c_char
+    use iso_c_binding, only: c_char
     class(plume_manager), intent(inout) :: handle
     character(kind=c_char,len=*), intent(in) :: config_str
     integer :: err
@@ -168,6 +209,7 @@ function plume_manager_configure_from_string(handle, config_str) result(err)
 end function
 
 function plume_manager_negotiate(handle, protocol_handle) result(err)
+    use iso_c_binding, only: c_char
     class(plume_manager), intent(inout) :: handle
     class(plume_protocol), intent(inout) :: protocol_handle
     integer :: err
@@ -175,19 +217,41 @@ function plume_manager_negotiate(handle, protocol_handle) result(err)
 end function
 
 function plume_manager_feed_plugins(handle, fdata) result(err)
+  use iso_c_binding, only: c_char
   class(plume_manager), intent(inout) :: handle
-  class(plume_data), intent(in) :: fdata    
+  class(plume_data), intent(in) :: fdata
   integer :: err
   err = plume_manager_feed_plugins_interf(handle%impl, fdata%impl)
 end function
 
-function plume_manager_run(handle) result(err)
+function plume_manager_run(handle, tag_id, parent_id) result(err)
+    use iso_c_binding, only: c_int, c_bool
     class(plume_manager), intent(inout) :: handle
+    integer(c_int), intent(in), optional :: tag_id
+    integer(c_int), intent(in), optional :: parent_id
     integer :: err
-    err = plume_manager_run_interf(handle%impl)
+    logical(c_bool) :: has_parent
+    integer(c_int) :: run_tag
+    integer(c_int) :: parent
+
+    if (present(tag_id)) then
+        run_tag = tag_id
+    else
+        run_tag = PLUME_TAG_RUN
+    end if
+
+    if (present(parent_id)) then
+        has_parent = .true.
+        parent = parent_id
+    else
+        has_parent = .false.
+        parent = run_tag
+    end if
+
+    err = plume_manager_run_interf(handle%impl, run_tag, has_parent, parent)
 end function
 
-! TODO: this really need to be checked!! not testing for errors, but returns a char*
+! TODO: this really need to be checked!! not testing for errors, but returns a string
 function plume_manager_active_fields(handle) result(fields_str)
     use iso_c_binding, only: c_ptr
     class(plume_manager), intent(inout) :: handle    
@@ -196,9 +260,10 @@ function plume_manager_active_fields(handle) result(fields_str)
     integer :: err
     err = plume_manager_active_fields_interf(handle%impl, fields_ptr)
     fields_str = fortranise_cstr(fields_ptr)
+    err = plume_delete_string(fields_ptr) ! free C-string
 end function
 
-! TODO: this really need to be checked!! not testing for errors, but returns a char*
+! TODO: this really need to be checked!! not testing for errors, but returns a string
 function plume_manager_active_fields_catalogue(handle) result(active_catalogue)
     use iso_c_binding, only: c_ptr
     class(plume_manager), intent(inout) :: handle
@@ -232,9 +297,51 @@ function plume_manager_is_plugin_activated(handle, name, is_plugin) result(err)
     err = plume_manager_is_plugin_activated_interf(handle%impl, c_str(name), is_plugin)
 end function
 
+! Not testing for errors, returns a string
+function plume_manager_current_state_name(handle) result(state_name)
+    use iso_c_binding, only: c_ptr
+    class(plume_manager), intent(inout) :: handle
+    character(:), allocatable, target :: state_name
+    type(c_ptr) :: state_name_ptr
+    integer :: err
+    err = plume_manager_current_state_name_interf(handle%impl, state_name_ptr)
+    state_name = fortranise_cstr(state_name_ptr)
+    err = plume_delete_string(state_name_ptr) ! free C-string
+end function
+
+! Not testing for errors, returns a string
+function plume_manager_current_state_parent(handle) result(state_parent)
+    use iso_c_binding, only: c_ptr
+    class(plume_manager), intent(inout) :: handle
+    character(:), allocatable, target :: state_parent
+    type(c_ptr) :: state_parent_ptr
+    integer :: err
+    err = plume_manager_current_state_parent_interf(handle%impl, state_parent_ptr)
+    state_parent = fortranise_cstr(state_parent_ptr)
+    err = plume_delete_string(state_parent_ptr) ! free C-string
+end function
+
+function plume_manager_current_state_iteration(handle, iteration) result(err)
+    use iso_c_binding, only: c_int, c_int64_t
+    class(plume_manager), intent(inout) :: handle
+    integer(c_int64_t), intent(inout) :: iteration
+    integer(c_int) :: err
+    err = plume_manager_current_state_iteration_interf(handle%impl, iteration)
+end function
+
+function plume_manager_current_state_iteration_rel(handle, iteration_rel) result(err)
+    use iso_c_binding, only: c_int, c_int64_t
+    class(plume_manager), intent(inout) :: handle
+    integer(c_int64_t), intent(inout) :: iteration_rel
+    integer(c_int) :: err
+    err = plume_manager_current_state_iteration_rel_interf(handle%impl, iteration_rel)
+end function
+
 function plume_manager_finalise(handle) result(err)
     class(plume_manager), intent(inout) :: handle
-    integer :: err        
+    integer :: err
+
+    err = 0
     if (handle%is_finalised .eqv. .false.) then
         ! teardown plugins and delete handle
         err = plume_manager_teardown_interf(handle%impl)

--- a/src/plume/api/plume_state.F90
+++ b/src/plume/api/plume_state.F90
@@ -1,0 +1,94 @@
+! (C) Copyright 2023- ECMWF.
+!
+! This software is licensed under the terms of the Apache Licence Version 2.0
+! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+!
+! In applying this licence, ECMWF does not waive the privileges and immunities
+! granted to it by virtue of its status as an intergovernmental organisation nor
+! does it submit to any jurisdiction.
+module plume_state_module
+
+use iso_c_binding
+
+use plume_utils_module, only : fortranise_cstr
+use plume_utils_module, only : plume_delete_string
+
+implicit none
+private
+
+public :: plume_state_current_name
+public :: plume_state_current_parent
+public :: plume_state_current_iteration
+public :: plume_state_current_iteration_rel
+
+interface
+
+function plume_state_current_name_interf(state_name) result(err) &
+    & bind(C, name="plume_state_current_name")
+    use iso_c_binding, only: c_ptr, c_int
+    type(c_ptr), intent(inout) :: state_name
+    integer(c_int) :: err
+end function
+
+function plume_state_current_parent_interf(state_parent) result(err) &
+    & bind(C, name="plume_state_current_parent")
+    use iso_c_binding, only: c_ptr, c_int
+    type(c_ptr), intent(inout) :: state_parent
+    integer(c_int) :: err
+end function
+
+function plume_state_current_iteration_interf(iteration) result(err) &
+    & bind(C, name="plume_state_current_iteration")
+    use iso_c_binding, only: c_int, c_int64_t
+    integer(c_int64_t), intent(inout) :: iteration
+    integer(c_int) :: err
+end function
+
+function plume_state_current_iteration_rel_interf(iteration_rel) result(err) &
+    & bind(C, name="plume_state_current_iteration_rel")
+    use iso_c_binding, only: c_int, c_int64_t
+    integer(c_int64_t), intent(inout) :: iteration_rel
+    integer(c_int) :: err
+end function
+
+end interface
+
+contains
+
+! Not testing for errors, returns a string
+function plume_state_current_name() result(state_name)
+    use iso_c_binding, only: c_ptr
+    character(:), allocatable, target :: state_name
+    type(c_ptr) :: state_name_ptr
+    integer :: err
+    err = plume_state_current_name_interf(state_name_ptr)
+    state_name = fortranise_cstr(state_name_ptr)
+    err = plume_delete_string(state_name_ptr) ! free C-string
+end function
+
+! Not testing for errors, returns a string
+function plume_state_current_parent() result(state_parent)
+    use iso_c_binding, only: c_ptr
+    character(:), allocatable, target :: state_parent
+    type(c_ptr) :: state_parent_ptr
+    integer :: err
+    err = plume_state_current_parent_interf(state_parent_ptr)
+    state_parent = fortranise_cstr(state_parent_ptr)
+    err = plume_delete_string(state_parent_ptr) ! free C-string
+end function
+
+function plume_state_current_iteration(iteration) result(err)
+    use iso_c_binding, only: c_int, c_int64_t
+    integer(c_int64_t), intent(inout) :: iteration
+    integer(c_int) :: err
+    err = plume_state_current_iteration_interf(iteration)
+end function
+
+function plume_state_current_iteration_rel(iteration_rel) result(err)
+    use iso_c_binding, only: c_int, c_int64_t
+    integer(c_int64_t), intent(inout) :: iteration_rel
+    integer(c_int) :: err
+    err = plume_state_current_iteration_rel_interf(iteration_rel)
+end function
+
+end module

--- a/src/plume/api/plume_utils.F90
+++ b/src/plume/api/plume_utils.F90
@@ -14,6 +14,7 @@ implicit none
 private
 
 public :: fortranise_cstr
+public :: plume_delete_string
 
 
 interface
@@ -25,6 +26,13 @@ interface
     end function
 end interface
 
+interface
+    function plume_delete_string_interf(str) bind(C, name="plume_delete_string") result(err)
+        use iso_c_binding
+        type(c_ptr), value :: str
+        integer(c_int) :: err
+    end function
+end interface
 
 contains
 
@@ -40,5 +48,20 @@ function fortranise_cstr(cstr) result(fstr)
     call c_f_pointer(cstr, tmp, [length])
     fstr = transfer(tmp(1:length), fstr)
 end function
+
+! use plume_delete_string to free C-strings (e.g. allocated by Plume API functions)
+function plume_delete_string(str) result(err)
+    use iso_c_binding
+    type(c_ptr), intent(inout) :: str
+    integer(c_int) :: err
+
+    if (c_associated(str)) then
+        err = plume_delete_string_interf(str)
+        str = c_null_ptr
+    else
+        err = 0
+    end if
+end function
+
 
 end module

--- a/src/plume/utils.h
+++ b/src/plume/utils.h
@@ -17,9 +17,14 @@
 #include "eckit/utils/StringTools.h"
 #include "eckit/exception/Exceptions.h"
 
+#include "eckit/config/Configuration.h"
+
 
 namespace plume {
 
+/** @brief A simple class to represent a library version, and to compare versions.
+ *
+ */
 class LibVersion {
     public:
         LibVersion(std::string versionString) : versionString_{versionString} {
@@ -80,6 +85,67 @@ class LibVersion {
         std::string major_;
         std::string minor_;
         std::string patch_;
+};
+
+inline void indent(std::ostream& os, int n) {
+    for (int i = 0; i < n; i++) os << "  ";
+}
+
+/**
+ * @brief Recursively serialize an eckit configuration into a JSON-like string.
+ */
+inline void configToJson(const eckit::Configuration& cfg, std::ostream& os, int userIndent) {
+
+    os << "{\n";
+
+    auto keys = cfg.keys();
+
+    // Emit each key/value pair in order.
+    for (size_t i = 0; i < keys.size(); ++i) {
+
+        const auto& key = keys[i];
+
+        // Indent one level inside current object.
+        indent(os, userIndent + 1);
+        os << "\"" << key << "\": ";
+
+        // Branch by value kind: single sub-config, list of sub-configs, or scalar.
+        if (cfg.isSubConfiguration(key)) {
+
+            // Recurse into nested object.
+            auto child = cfg.getSubConfiguration(key);
+            configToJson(child, os, userIndent + 1);
+
+        } else if (cfg.isSubConfigurationList(key)) {
+
+            // Recurse into an array of nested objects.
+            auto childList = cfg.getSubConfigurations(key);
+
+            os << "[\n";
+            for (size_t j = 0; j < childList.size(); ++j) {
+                indent(os, userIndent + 2);
+                configToJson(childList[j], os, userIndent + 2);
+                if (j + 1 < childList.size()) os << ",";
+                os << "\n";
+            }
+
+            // Indent closing array bracket.
+            indent(os, userIndent + 1);
+            os << "]";
+
+        } else {
+
+            // Scalar fallback: represent scalar as a quoted string.
+            std::string value = cfg.getString(key);
+            os << "\"" << value << "\"";
+        }
+
+        if (i + 1 < keys.size()) os << ",";
+        os << "\n";
+    }
+
+    indent(os, userIndent);
+    os << "}";
 };
 
 } // namespace plume

--- a/tests/api/CMakeLists.txt
+++ b/tests/api/CMakeLists.txt
@@ -62,6 +62,14 @@ ecbuild_add_test( TARGET   plume_test_params_api
                     plume
 )
 
+ecbuild_add_test( TARGET   plume_test_state_api
+                  SOURCES
+                    test_api_utils.h
+                    test_state_api.cc
+                  LIBS
+                    plume
+)
+
 # Fortran API tests
 add_fctest( TARGET   plume_test_data_fapi
             SOURCES  test_data_api.F90
@@ -83,6 +91,12 @@ add_fctest( TARGET   plume_test_manager_fapi
 
 add_fctest( TARGET   plume_test_params_fapi
             SOURCES  test_params_api.F90
+            LIBS
+              plume_f
+)
+
+add_fctest( TARGET   plume_test_state_fapi
+            SOURCES  test_state_api.F90
             LIBS
               plume_f
 )

--- a/tests/api/test_manager_api.F90
+++ b/tests/api/test_manager_api.F90
@@ -13,8 +13,10 @@
 TESTSUITE( test_manager_fapi_suite )
 
 TEST( test_manager_fapi )
+use iso_c_binding, only : c_int64_t
 use atlas_module
 use plume_module
+use plume_tags_module, only : PLUME_TAG_RUN
 use fckit_module
 implicit none
 
@@ -43,6 +45,9 @@ real(c_double) :: param_dd1_fort = 888.8
 logical(c_bool) :: is_plugin_activated
 
 integer :: iter
+integer(c_int64_t) :: state_iter
+integer(c_int64_t) :: state_iter_rel
+character(:), allocatable :: state_name
 
 
 call atlas_library%initialise()
@@ -112,7 +117,22 @@ mgr_conf_str = '{' // &
 
 call plume_check(manager%initialise())
 call plume_check(manager%configure_from_string(trim(mgr_conf_str)))
+
+
+state_name = manager%current_state_name()
+call plume_check(manager%current_state_iteration(state_iter))
+call plume_check(manager%current_state_iteration_rel(state_iter_rel))
+FCTEST_CHECK(trim(state_name) == "configure")
+FCTEST_CHECK(state_iter == 1)
+FCTEST_CHECK(state_iter_rel == 1)
+
 call plume_check(manager%negotiate(offers))
+state_name = manager%current_state_name()
+call plume_check(manager%current_state_iteration(state_iter))
+call plume_check(manager%current_state_iteration_rel(state_iter_rel))
+FCTEST_CHECK(trim(state_name) == "negotiate")
+FCTEST_CHECK(state_iter == 1)
+FCTEST_CHECK(state_iter_rel == 1)
 
 ! check that the plugins are activated
 is_plugin_activated = .false.
@@ -146,9 +166,22 @@ call plume_check(data%provide_double("FORT_DD1", param_dd1) )
 ! feed plugins
 call plume_check(manager%feed_plugins(data))
 
+state_name = manager%current_state_name()
+call plume_check(manager%current_state_iteration(state_iter))
+call plume_check(manager%current_state_iteration_rel(state_iter_rel))
+FCTEST_CHECK(trim(state_name) == "feed_plugins")
+FCTEST_CHECK(state_iter == 1)
+FCTEST_CHECK(state_iter_rel == 1)
+
 ! run the model for 2 iterations
 do iter=1,2
-  call plume_check(manager%run())
+  call plume_check(manager%run(PLUME_TAG_RUN))
+  state_name = manager%current_state_name()
+  call plume_check(manager%current_state_iteration(state_iter))
+  call plume_check(manager%current_state_iteration_rel(state_iter_rel))
+  FCTEST_CHECK(trim(state_name) == "run")
+  FCTEST_CHECK(state_iter == iter)
+  FCTEST_CHECK(state_iter_rel == iter)
 enddo
 
 ! finalise

--- a/tests/api/test_manager_api.cc
+++ b/tests/api/test_manager_api.cc
@@ -24,6 +24,9 @@ CASE("test_manager_api") {
     plume_protocol_handle_t* protocol_handle;
     plume_manager_handle_t* mgr_handle;
     plume_data_handle_t* data_handle;
+    char* state_name;
+    int64_t state_iteration = -1;
+    int64_t state_iteration_rel = -1;
 
     int error_code = PlumeErrorValues::PLUME_ERROR_GENERAL_EXCEPTION;
 
@@ -92,7 +95,22 @@ CASE("test_manager_api") {
     // create manager handle
     EXPECT_PLUME_CODE_SUCCESS( plume_manager_create_handle(&mgr_handle));
     EXPECT_PLUME_CODE_SUCCESS( plume_manager_configure_from_string(mgr_handle, mgr_conf_str.c_str()));
+    EXPECT_PLUME_CODE_SUCCESS( plume_manager_current_state_name(mgr_handle, &state_name));
+    EXPECT_EQUAL(std::string(state_name), "configure");
+    delete[] state_name;
+    EXPECT_PLUME_CODE_SUCCESS( plume_manager_current_state_iteration(mgr_handle, &state_iteration));
+    EXPECT_EQUAL(state_iteration, 1);
+    EXPECT_PLUME_CODE_SUCCESS( plume_manager_current_state_iteration_rel(mgr_handle, &state_iteration_rel));
+    EXPECT_EQUAL(state_iteration_rel, 1);
+
     EXPECT_PLUME_CODE_SUCCESS( plume_manager_negotiate(mgr_handle, protocol_handle));
+    EXPECT_PLUME_CODE_SUCCESS( plume_manager_current_state_name(mgr_handle, &state_name));
+    EXPECT_EQUAL(std::string(state_name), "negotiate");
+    delete[] state_name;
+    EXPECT_PLUME_CODE_SUCCESS( plume_manager_current_state_iteration(mgr_handle, &state_iteration));
+    EXPECT_EQUAL(state_iteration, 1);
+    EXPECT_PLUME_CODE_SUCCESS( plume_manager_current_state_iteration_rel(mgr_handle, &state_iteration_rel));
+    EXPECT_EQUAL(state_iteration_rel, 1);
 
     // check that the plugins are activated
     bool plugin_activated = false;
@@ -133,10 +151,24 @@ CASE("test_manager_api") {
 
     // Feed the plugins (i.e. each plugin grabs its own share of data)
     EXPECT_PLUME_CODE_SUCCESS( plume_manager_feed_plugins(mgr_handle, data_handle) );
+    EXPECT_PLUME_CODE_SUCCESS( plume_manager_current_state_name(mgr_handle, &state_name));
+    EXPECT_EQUAL(std::string(state_name), "feed_plugins");
+    delete[] state_name;
+    EXPECT_PLUME_CODE_SUCCESS( plume_manager_current_state_iteration(mgr_handle, &state_iteration));
+    EXPECT_EQUAL(state_iteration, 1);
+    EXPECT_PLUME_CODE_SUCCESS( plume_manager_current_state_iteration_rel(mgr_handle, &state_iteration_rel));
+    EXPECT_EQUAL(state_iteration_rel, 1);
 
     // run the plugin for 2 iterations
     for (int i = 0; i < 2; ++i) {
-        EXPECT_PLUME_CODE_SUCCESS( plume_manager_run(mgr_handle));
+      EXPECT_PLUME_CODE_SUCCESS( plume_manager_run(mgr_handle, PLUME_TAG_ID_RUN, false, PLUME_TAG_ID_RUN));
+      EXPECT_PLUME_CODE_SUCCESS( plume_manager_current_state_name(mgr_handle, &state_name));
+      EXPECT_EQUAL(std::string(state_name), "run");
+      delete[] state_name;
+      EXPECT_PLUME_CODE_SUCCESS( plume_manager_current_state_iteration(mgr_handle, &state_iteration));
+      EXPECT_EQUAL(state_iteration, i + 1);
+      EXPECT_PLUME_CODE_SUCCESS( plume_manager_current_state_iteration_rel(mgr_handle, &state_iteration_rel));
+      EXPECT_EQUAL(state_iteration_rel, i + 1);
     }
 
     // finalise plume

--- a/tests/api/test_state_api.F90
+++ b/tests/api/test_state_api.F90
@@ -1,0 +1,221 @@
+! (C) Copyright 2023- ECMWF.
+!
+! This software is licensed under the terms of the Apache Licence Version 2.0
+! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+!
+! In applying this licence, ECMWF does not waive the privileges and immunities
+! granted to it by virtue of its status as an intergovernmental organisation nor
+! does it submit to any jurisdiction.
+
+#include "fckit/fctest.h"
+
+
+TESTSUITE( test_state_fapi_suite )
+
+! -----------------------------------------------------------------------
+! Tests the standalone plume_state_* API (plume_state_module), which
+! queries the global PlumeState singleton independently of the manager
+! handle.  The manager is used only to drive state transitions.
+! -----------------------------------------------------------------------
+
+TEST( test_state_fapi_lifecycle )
+use iso_c_binding, only : c_null_char, c_int64_t
+use plume_module
+use plume_tags_module, only : PLUME_TAG_RUN
+implicit none
+
+type(plume_protocol) :: offers
+type(plume_manager) :: manager
+type(plume_data) :: data
+
+character(len=2000) :: mgr_conf_str
+
+integer :: param_i = 1
+integer :: param_j = 2
+
+integer :: iter
+integer(c_int64_t) :: state_iter
+integer(c_int64_t) :: state_iter_rel
+character(:), allocatable :: state_name
+
+call plume_check(plume_initialise())
+
+! ----- offers -----
+call plume_check(offers%initialise())
+call plume_check(offers%offer_int("I", "always", "param I"))
+call plume_check(offers%offer_int("J", "always", "param J"))
+
+mgr_conf_str = '{' // &
+'"plugins": [ ' // &
+'    { ' // &
+'        "lib": "plume_plugin_test_api", ' // &
+'        "name": "PluginTestAPI", ' // &
+'        "parameters": [ ' // &
+'            [ ' // &
+'                {"name":"I", "type":"INT"}, ' // &
+'                {"name":"J", "type":"INT"} ' // &
+'            ] ' // &
+'        ], ' // &
+'        "core-config": {} ' // &
+'    } ' // &
+'] ' // &
+'}' // c_null_char
+
+! ----- configure -----
+call plume_check(manager%initialise())
+call plume_check(manager%configure_from_string(trim(mgr_conf_str)))
+
+state_name = plume_state_current_name()
+call plume_check(plume_state_current_iteration(state_iter))
+call plume_check(plume_state_current_iteration_rel(state_iter_rel))
+FCTEST_CHECK(trim(state_name) == "configure")
+FCTEST_CHECK(state_iter == 1)
+FCTEST_CHECK(state_iter_rel == 1)
+
+! ----- negotiate -----
+call plume_check(manager%negotiate(offers))
+
+state_name = plume_state_current_name()
+call plume_check(plume_state_current_iteration(state_iter))
+call plume_check(plume_state_current_iteration_rel(state_iter_rel))
+FCTEST_CHECK(trim(state_name) == "negotiate")
+FCTEST_CHECK(state_iter == 1)
+FCTEST_CHECK(state_iter_rel == 1)
+
+! ----- feed plugins -----
+call plume_check(data%initialise())
+call plume_check(data%provide_int("I", param_i))
+call plume_check(data%provide_int("J", param_j))
+call plume_check(manager%feed_plugins(data))
+
+state_name = plume_state_current_name()
+call plume_check(plume_state_current_iteration(state_iter))
+call plume_check(plume_state_current_iteration_rel(state_iter_rel))
+FCTEST_CHECK(trim(state_name) == "feed_plugins")
+FCTEST_CHECK(state_iter == 1)
+FCTEST_CHECK(state_iter_rel == 1)
+
+! ----- run (3 iterations) -----
+do iter = 1, 3
+    call plume_check(manager%run(PLUME_TAG_RUN))
+
+    state_name = plume_state_current_name()
+    call plume_check(plume_state_current_iteration(state_iter))
+    call plume_check(plume_state_current_iteration_rel(state_iter_rel))
+    FCTEST_CHECK(trim(state_name) == "run")
+    FCTEST_CHECK(state_iter == int(iter, c_int64_t))
+    FCTEST_CHECK(state_iter_rel == int(iter, c_int64_t))
+enddo
+
+! ----- teardown -----
+call plume_check(manager%finalise())
+
+state_name = plume_state_current_name()
+call plume_check(plume_state_current_iteration(state_iter))
+call plume_check(plume_state_current_iteration_rel(state_iter_rel))
+FCTEST_CHECK(trim(state_name) == "teardown")
+FCTEST_CHECK(state_iter == 1)
+FCTEST_CHECK(state_iter_rel == 1)
+
+call plume_check(offers%finalise())
+call plume_check(data%finalise())
+call plume_check(plume_finalise())
+
+END_TEST
+
+
+TEST( test_state_fapi_custom_tags )
+use iso_c_binding, only : c_null_char, c_int64_t
+use plume_module
+use plume_tags_module
+implicit none
+
+type(plume_protocol) :: offers
+type(plume_manager) :: manager
+type(plume_data) :: data
+
+character(len=2000) :: mgr_conf_str
+
+integer :: param_i = 1
+integer :: param_j = 2
+
+integer :: iter
+integer(c_int64_t) :: state_iter
+integer(c_int64_t) :: state_iter_rel
+character(:), allocatable :: state_name
+
+call plume_check(plume_initialise())
+
+call plume_check(offers%initialise())
+call plume_check(offers%offer_int("I", "always", "param I"))
+call plume_check(offers%offer_int("J", "always", "param J"))
+
+mgr_conf_str = '{' // &
+'"plugins": [ ' // &
+'    { ' // &
+'        "lib": "plume_plugin_test_api", ' // &
+'        "name": "PluginTestAPI", ' // &
+'        "parameters": [ ' // &
+'            [ ' // &
+'                {"name":"I", "type":"INT"}, ' // &
+'                {"name":"J", "type":"INT"} ' // &
+'            ] ' // &
+'        ], ' // &
+'        "core-config": {} ' // &
+'    } ' // &
+'] ' // &
+'}' // c_null_char
+
+call plume_check(manager%initialise())
+call plume_check(manager%configure_from_string(trim(mgr_conf_str)))
+
+state_name = plume_state_current_name()
+FCTEST_CHECK(trim(state_name) == "configure")
+
+call plume_check(manager%negotiate(offers))
+
+state_name = plume_state_current_name()
+FCTEST_CHECK(trim(state_name) == "negotiate")
+
+call plume_check(data%initialise())
+call plume_check(data%provide_int("I", param_i))
+call plume_check(data%provide_int("J", param_j))
+call plume_check(manager%feed_plugins(data))
+
+state_name = plume_state_current_name()
+FCTEST_CHECK(trim(state_name) == "feed_plugins")
+
+! ----- nested run: outer (2 iterations) / inner (3 iterations each) -----
+do iter = 1, 2
+    call plume_check(manager%run(PLUME_TAG_RUN_LVL1))
+
+    state_name = plume_state_current_name()
+    call plume_check(plume_state_current_iteration(state_iter))
+    call plume_check(plume_state_current_iteration_rel(state_iter_rel))
+    FCTEST_CHECK(trim(state_name) == "run_lvl1")
+    FCTEST_CHECK(state_iter == int(iter, c_int64_t))
+    FCTEST_CHECK(state_iter_rel == int(iter, c_int64_t))
+
+    ! inner run -- relative iteration resets each time outer advances
+    call plume_check(manager%run(PLUME_TAG_RUN_LVL2, PLUME_TAG_RUN_LVL1))
+    state_name = plume_state_current_name()
+    call plume_check(plume_state_current_iteration(state_iter))
+    call plume_check(plume_state_current_iteration_rel(state_iter_rel))
+    FCTEST_CHECK(trim(state_name) == "run_lvl2")
+    FCTEST_CHECK(state_iter == int(iter, c_int64_t))   ! cumulative
+    FCTEST_CHECK(state_iter_rel == 1)                  ! reset by parent advance
+enddo
+
+call plume_check(manager%finalise())
+
+state_name = plume_state_current_name()
+FCTEST_CHECK(trim(state_name) == "teardown")
+
+call plume_check(offers%finalise())
+call plume_check(data%finalise())
+call plume_check(plume_finalise())
+
+END_TEST
+
+
+END_TESTSUITE

--- a/tests/api/test_state_api.cc
+++ b/tests/api/test_state_api.cc
@@ -1,0 +1,212 @@
+/*
+ * (C) Copyright 2023- ECMWF.
+ *
+ * This software is licensed under the terms of the Apache Licence Version 2.0
+ * which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * In applying this licence, ECMWF does not waive the privileges and immunities
+ * granted to it by virtue of its status as an intergovernmental organisation nor
+ * does it submit to any jurisdiction.
+ */
+
+#include <cstdint>
+#include <string>
+
+#include "eckit/testing/Test.h"
+#include "eckit/runtime/Main.h"
+#include "plume/api/plume.h"
+#include "test_api_utils.h"
+
+using namespace eckit::testing;
+
+namespace plume::test {
+
+// -----------------------------------------------------------------------
+// Tests the standalone plume_state_* C API, which queries the global
+// PlumeState singleton independently of the manager handle.
+// The manager is used only to drive state transitions.
+// -----------------------------------------------------------------------
+
+static const std::string MGR_CONF_STR = R"YAML(
+plugins:
+  - lib: plume_plugin_test_api
+    name: PluginTestAPI
+    parameters:
+      -
+        - name: I
+          type: INT
+        - name: J
+          type: INT
+    core-config: {}
+)YAML";
+
+CASE("test_state_api_lifecycle") {
+
+    plume_protocol_handle_t* protocol_handle = nullptr;
+    plume_manager_handle_t*  mgr_handle      = nullptr;
+    plume_data_handle_t*     data_handle     = nullptr;
+    char*    state_name          = nullptr;
+    int64_t  state_iteration     = -1;
+    int64_t  state_iteration_rel = -1;
+
+    EXPECT_PLUME_CODE_SUCCESS(plume_initialise(eckit::Main::instance().argc(),
+                                               eckit::Main::instance().argv()));
+
+    // ----- offers -----
+    EXPECT_PLUME_CODE_SUCCESS(plume_protocol_create_handle(&protocol_handle));
+    EXPECT_PLUME_CODE_SUCCESS(plume_protocol_offer_int(protocol_handle, "I", "always", "param I"));
+    EXPECT_PLUME_CODE_SUCCESS(plume_protocol_offer_int(protocol_handle, "J", "always", "param J"));
+
+    // ----- configure -----
+    EXPECT_PLUME_CODE_SUCCESS(plume_manager_create_handle(&mgr_handle));
+    EXPECT_PLUME_CODE_SUCCESS(plume_manager_configure_from_string(mgr_handle, MGR_CONF_STR.c_str()));
+
+    EXPECT_PLUME_CODE_SUCCESS(plume_state_current_name(&state_name));
+    EXPECT_EQUAL(std::string(state_name), "configure");
+    delete[] state_name;
+    EXPECT_PLUME_CODE_SUCCESS(plume_state_current_iteration(&state_iteration));
+    EXPECT_EQUAL(state_iteration, 1);
+    EXPECT_PLUME_CODE_SUCCESS(plume_state_current_iteration_rel(&state_iteration_rel));
+    EXPECT_EQUAL(state_iteration_rel, 1);
+
+    // ----- negotiate -----
+    EXPECT_PLUME_CODE_SUCCESS(plume_manager_negotiate(mgr_handle, protocol_handle));
+
+    EXPECT_PLUME_CODE_SUCCESS(plume_state_current_name(&state_name));
+    EXPECT_EQUAL(std::string(state_name), "negotiate");
+    delete[] state_name;
+    EXPECT_PLUME_CODE_SUCCESS(plume_state_current_iteration(&state_iteration));
+    EXPECT_EQUAL(state_iteration, 1);
+    EXPECT_PLUME_CODE_SUCCESS(plume_state_current_iteration_rel(&state_iteration_rel));
+    EXPECT_EQUAL(state_iteration_rel, 1);
+
+    // ----- feed plugins -----
+    int param_i = 1;
+    int param_j = 2;
+    EXPECT_PLUME_CODE_SUCCESS(plume_data_create_handle_t(&data_handle));
+    EXPECT_PLUME_CODE_SUCCESS(plume_data_provide_int(data_handle, "I", &param_i));
+    EXPECT_PLUME_CODE_SUCCESS(plume_data_provide_int(data_handle, "J", &param_j));
+    EXPECT_PLUME_CODE_SUCCESS(plume_manager_feed_plugins(mgr_handle, data_handle));
+
+    EXPECT_PLUME_CODE_SUCCESS(plume_state_current_name(&state_name));
+    EXPECT_EQUAL(std::string(state_name), "feed_plugins");
+    delete[] state_name;
+    EXPECT_PLUME_CODE_SUCCESS(plume_state_current_iteration(&state_iteration));
+    EXPECT_EQUAL(state_iteration, 1);
+    EXPECT_PLUME_CODE_SUCCESS(plume_state_current_iteration_rel(&state_iteration_rel));
+    EXPECT_EQUAL(state_iteration_rel, 1);
+
+    // ----- run (3 iterations) -----
+    for (int i = 1; i <= 3; ++i) {
+      EXPECT_PLUME_CODE_SUCCESS(plume_manager_run(mgr_handle, PLUME_TAG_ID_RUN, false, PLUME_TAG_ID_RUN));
+
+        EXPECT_PLUME_CODE_SUCCESS(plume_state_current_name(&state_name));
+        EXPECT_EQUAL(std::string(state_name), "run");
+        delete[] state_name;
+        EXPECT_PLUME_CODE_SUCCESS(plume_state_current_iteration(&state_iteration));
+        EXPECT_EQUAL(state_iteration, static_cast<int64_t>(i));
+        EXPECT_PLUME_CODE_SUCCESS(plume_state_current_iteration_rel(&state_iteration_rel));
+        EXPECT_EQUAL(state_iteration_rel, static_cast<int64_t>(i));
+    }
+
+    // ----- teardown -----
+    EXPECT_PLUME_CODE_SUCCESS(plume_manager_teardown(mgr_handle));
+
+    EXPECT_PLUME_CODE_SUCCESS(plume_state_current_name(&state_name));
+    EXPECT_EQUAL(std::string(state_name), "teardown");
+    delete[] state_name;
+    EXPECT_PLUME_CODE_SUCCESS(plume_state_current_iteration(&state_iteration));
+    EXPECT_EQUAL(state_iteration, 1);
+    EXPECT_PLUME_CODE_SUCCESS(plume_state_current_iteration_rel(&state_iteration_rel));
+    EXPECT_EQUAL(state_iteration_rel, 1);
+
+    EXPECT_PLUME_CODE_SUCCESS(plume_manager_delete_handle(mgr_handle));
+    EXPECT_PLUME_CODE_SUCCESS(plume_protocol_delete_handle(protocol_handle));
+    EXPECT_PLUME_CODE_SUCCESS(plume_data_delete_handle(data_handle));
+    EXPECT_PLUME_CODE_SUCCESS(plume_finalise());
+}
+
+
+CASE("test_state_api_enum_tags") {
+
+    plume_protocol_handle_t* protocol_handle = nullptr;
+    plume_manager_handle_t*  mgr_handle      = nullptr;
+    plume_data_handle_t*     data_handle     = nullptr;
+    char*    state_name          = nullptr;
+    int64_t  state_iteration     = -1;
+    int64_t  state_iteration_rel = -1;
+
+    EXPECT_PLUME_CODE_SUCCESS(plume_initialise(eckit::Main::instance().argc(),
+                                               eckit::Main::instance().argv()));
+
+    EXPECT_PLUME_CODE_SUCCESS(plume_protocol_create_handle(&protocol_handle));
+    EXPECT_PLUME_CODE_SUCCESS(plume_protocol_offer_int(protocol_handle, "I", "always", "param I"));
+    EXPECT_PLUME_CODE_SUCCESS(plume_protocol_offer_int(protocol_handle, "J", "always", "param J"));
+
+    EXPECT_PLUME_CODE_SUCCESS(plume_manager_create_handle(&mgr_handle));
+    EXPECT_PLUME_CODE_SUCCESS(plume_manager_configure_from_string(mgr_handle, MGR_CONF_STR.c_str()));
+
+    EXPECT_PLUME_CODE_SUCCESS(plume_state_current_name(&state_name));
+    EXPECT_EQUAL(std::string(state_name), "configure");
+    delete[] state_name;
+
+    EXPECT_PLUME_CODE_SUCCESS(plume_manager_negotiate(mgr_handle, protocol_handle));
+
+    EXPECT_PLUME_CODE_SUCCESS(plume_state_current_name(&state_name));
+    EXPECT_EQUAL(std::string(state_name), "negotiate");
+    delete[] state_name;
+
+    int param_i = 1;
+    int param_j = 2;
+    EXPECT_PLUME_CODE_SUCCESS(plume_data_create_handle_t(&data_handle));
+    EXPECT_PLUME_CODE_SUCCESS(plume_data_provide_int(data_handle, "I", &param_i));
+    EXPECT_PLUME_CODE_SUCCESS(plume_data_provide_int(data_handle, "J", &param_j));
+    EXPECT_PLUME_CODE_SUCCESS(plume_manager_feed_plugins(mgr_handle, data_handle));
+
+    EXPECT_PLUME_CODE_SUCCESS(plume_state_current_name(&state_name));
+    EXPECT_EQUAL(std::string(state_name), "feed_plugins");
+    delete[] state_name;
+
+    // ----- nested run: outer (2 iterations) / inner (1 per outer) -----
+    for (int i = 1; i <= 2; ++i) {
+      EXPECT_PLUME_CODE_SUCCESS(plume_manager_run(mgr_handle, PLUME_TAG_ID_RUN_LVL1, false, PLUME_TAG_ID_RUN_LVL1));
+
+        EXPECT_PLUME_CODE_SUCCESS(plume_state_current_name(&state_name));
+        EXPECT_EQUAL(std::string(state_name), "run_lvl1");
+        delete[] state_name;
+        EXPECT_PLUME_CODE_SUCCESS(plume_state_current_iteration(&state_iteration));
+        EXPECT_EQUAL(state_iteration, static_cast<int64_t>(i));
+        EXPECT_PLUME_CODE_SUCCESS(plume_state_current_iteration_rel(&state_iteration_rel));
+        EXPECT_EQUAL(state_iteration_rel, static_cast<int64_t>(i));
+
+        // inner run -- relative iteration resets when outer advances
+        EXPECT_PLUME_CODE_SUCCESS(plume_manager_run(mgr_handle, PLUME_TAG_ID_RUN_LVL2, true, PLUME_TAG_ID_RUN_LVL1));
+
+        EXPECT_PLUME_CODE_SUCCESS(plume_state_current_name(&state_name));
+        EXPECT_EQUAL(std::string(state_name), "run_lvl2");
+        delete[] state_name;
+        EXPECT_PLUME_CODE_SUCCESS(plume_state_current_iteration(&state_iteration));
+        EXPECT_EQUAL(state_iteration, static_cast<int64_t>(i));  // cumulative
+        EXPECT_PLUME_CODE_SUCCESS(plume_state_current_iteration_rel(&state_iteration_rel));
+        EXPECT_EQUAL(state_iteration_rel, int64_t{1});            // reset by parent advance
+    }
+
+    EXPECT_PLUME_CODE_SUCCESS(plume_manager_teardown(mgr_handle));
+
+    EXPECT_PLUME_CODE_SUCCESS(plume_state_current_name(&state_name));
+    EXPECT_EQUAL(std::string(state_name), "teardown");
+    delete[] state_name;
+
+    EXPECT_PLUME_CODE_SUCCESS(plume_manager_delete_handle(mgr_handle));
+    EXPECT_PLUME_CODE_SUCCESS(plume_protocol_delete_handle(protocol_handle));
+    EXPECT_PLUME_CODE_SUCCESS(plume_data_delete_handle(data_handle));
+    EXPECT_PLUME_CODE_SUCCESS(plume_finalise());
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+
+}  // namespace plume::test
+
+int main(int argc, char** argv) {
+    return eckit::testing::run_tests(argc, argv);
+}

--- a/tests/core/CMakeLists.txt
+++ b/tests/core/CMakeLists.txt
@@ -50,6 +50,8 @@ ecbuild_add_library( TARGET simple_plugins
   SOURCES 
     simple_plugin.h
     simple_plugin.cc
+    simple_config_plugin.h
+    simple_config_plugin.cc
     simple_atlas_plugin.h
     simple_atlas_plugin.cc
   PRIVATE_LIBS

--- a/tests/core/simple_config_plugin.cc
+++ b/tests/core/simple_config_plugin.cc
@@ -1,0 +1,37 @@
+/*
+ * (C) Copyright 2023- ECMWF.
+ *
+ * This software is licensed under the terms of the Apache Licence Version 2.0
+ * which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * In applying this licence, ECMWF does not waive the privileges and immunities
+ * granted to it by virtue of its status as an intergovernmental organisation nor
+ * does it submit to any jurisdiction.
+ */
+#include "simple_config_plugin.h"
+
+#include <iostream>
+
+namespace plume_example_plugin {
+
+REGISTER_LIBRARY(SimpleConfigPlugin)
+
+SimpleConfigPlugin::SimpleConfigPlugin() : Plugin("SimpleConfigPlugin") {}
+
+const SimpleConfigPlugin& SimpleConfigPlugin::instance() {
+    static SimpleConfigPlugin instance;
+    return instance;
+}
+
+static plume::PluginCoreBuilder<SimpleConfigPluginCore> runnable_plugincore_simple_config_builder_;
+
+SimpleConfigPluginCore::SimpleConfigPluginCore(const eckit::Configuration& conf) : PluginCore(conf) {}
+
+void SimpleConfigPluginCore::run() {
+    std::cout << "[SimpleConfigPlugin] state=" << currentStateName()
+              << " (parent=" << currentStateParent()
+              << "), iter=" << currentStateIteration()
+              << ", rel_iter=" << currentStateIterationRel() << std::endl;
+}
+
+}  // namespace plume_example_plugin

--- a/tests/core/simple_config_plugin.h
+++ b/tests/core/simple_config_plugin.h
@@ -1,0 +1,47 @@
+/*
+ * (C) Copyright 2023- ECMWF.
+ *
+ * This software is licensed under the terms of the Apache Licence Version 2.0
+ * which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * In applying this licence, ECMWF does not waive the privileges and immunities
+ * granted to it by virtue of its status as an intergovernmental organisation nor
+ * does it submit to any jurisdiction.
+ */
+#pragma once
+
+#include <string>
+
+#include "plume/Plugin.h"
+#include "plume/PluginCore.h"
+
+namespace plume_example_plugin {
+
+// PluginCore that relies on configuration-driven parameter selection only.
+class SimpleConfigPluginCore final : public plume::PluginCore {
+public:
+    explicit SimpleConfigPluginCore(const eckit::Configuration& conf);
+    void run() override;
+    constexpr static const char* type() { return "simple-config-plugincore"; }
+};
+
+class SimpleConfigPlugin final : public plume::Plugin {
+public:
+    SimpleConfigPlugin();
+
+    plume::Protocol negotiate() override {
+        plume::Protocol protocol;
+        // No hardcoded required parameters; selection is fully config-driven.
+        return protocol;
+    }
+
+    static const SimpleConfigPlugin& instance();
+
+    std::string version() const override { return "0.0.1-SimpleConfig"; }
+
+    std::string gitsha1(unsigned int count) const override { return "undefined"; }
+
+    std::string plugincoreName() const override { return SimpleConfigPluginCore::type(); }
+};
+
+}  // namespace plume_example_plugin

--- a/tests/core/simple_plugin.cc
+++ b/tests/core/simple_plugin.cc
@@ -31,6 +31,11 @@ static plume::PluginCoreBuilder<SimplePluginCore> runnable_plugincore_FooBuilder
 SimplePluginCore::SimplePluginCore(const eckit::Configuration& conf) : PluginCore(conf) {}
 
 void SimplePluginCore::run() {
+
+    eckit::Log::info() << "Current State Name: " << currentStateName() << std::endl;
+    eckit::Log::info() << "Current State Iteration: " << currentStateIteration() << std::endl;
+    eckit::Log::info() << "Current State Iteration (Rel): " << currentStateIterationRel() << std::endl;
+
     eckit::Log::info() << "Consuming parameters: (" 
                        << "I=" << modelData().getParam<int>("I") << ", "
                        << "J=" << modelData().getParam<int>("J") << ", "

--- a/tests/core/test_manager.cc
+++ b/tests/core/test_manager.cc
@@ -192,6 +192,321 @@ CASE("test_feeding_plugins") {
 }
 
 
+CASE("test_config_plugin_nested_run_smoke") {
+    ManagerTestAccess::reset();
+
+    std::string mgr_conf_str = R"YAML(
+    plugins:
+      - lib: simple_plugins
+        name: SimpleConfigPlugin
+        core-config: {}
+    )YAML";
+
+    eckit::YAMLConfiguration mgr_cfg(mgr_conf_str);
+
+    std::string data_conf_str = R"YAML(
+    offered:
+      - name: I
+        type: INT
+        available: always
+        comment: none-1
+    )YAML";
+
+    eckit::YAMLConfiguration data_cfg(data_conf_str);
+
+    plume::Manager::configure(mgr_cfg);
+    plume::Manager::negotiate(data_cfg);
+
+    plume::data::ModelData data;
+    data.createParam("I", 1);
+    EXPECT_NO_THROW(plume::Manager::feedPlugins(data));
+
+    for (int i = 0; i < 3; ++i) {
+      EXPECT_NO_THROW(plume::Manager::run(plume::PlumeTag::RUN_LVL1));
+        for (int j = 0; j < 4; ++j) {
+        EXPECT_NO_THROW(plume::Manager::run(plume::PlumeTag::RUN_LVL2, plume::PlumeTag::RUN_LVL1));
+            for (int k = 0; k < 2; ++k) {
+          EXPECT_NO_THROW(plume::Manager::run(plume::PlumeTag::RUN_LVL3, plume::PlumeTag::RUN_LVL2));
+            }
+        }
+    }
+
+    EXPECT_NO_THROW(plume::Manager::teardown());
+}
+
+
+CASE("test_tagged_plume_state") {
+    ManagerTestAccess::reset();
+
+    std::string mgr_conf_str = R"YAML(
+    plugins:
+      - lib: simple_plugins
+        name: SimplePlugin
+        core-config: {}
+    )YAML";
+
+    eckit::YAMLConfiguration mgr_cfg(mgr_conf_str);
+
+    std::string data_conf_str = R"YAML(
+    offered:
+      - name: I
+        type: INT
+        available: always
+        comment: none-1
+      - name: J
+        type: INT
+        available: always
+        comment: none-2
+      - name: K
+        type: INT
+        available: always
+        comment: none-3
+    )YAML";
+
+    eckit::YAMLConfiguration data_cfg(data_conf_str);
+
+    plume::Manager::configure(mgr_cfg);
+    plume::Manager::negotiate(data_cfg);
+
+    plume::data::ModelData data;
+    data.createParam("I", 1);
+    data.createParam("J", 2);
+    data.createParam("K", 3);
+
+    plume::Manager::feedPlugins(data);
+
+    // run outer once
+    plume::Manager::run(plume::PlumeTag::RUN_LVL1);
+
+    [&]() {
+
+      // run inner 5 times, and innermost 2 times
+      for (int i = 0; i < 5; ++i) {
+          plume::Manager::run(plume::PlumeTag::RUN_LVL2);
+
+          for (int j = 0; j < 2; ++j) {
+            plume::Manager::run(plume::PlumeTag::RUN_LVL3, plume::PlumeTag::RUN_LVL2);
+
+            for (int k = 0; k < 2; ++k) {
+              plume::Manager::run(plume::PlumeTag::RUN_LVL4, plume::PlumeTag::RUN_LVL3);
+            }
+
+            for (int l = 0; l < 4; ++l) {
+              plume::Manager::run(plume::PlumeTag::RUN_LVL5, plume::PlumeTag::RUN_LVL3);
+              if (i == 2 && l == 1) {
+                return;
+              }
+            }
+          }        
+      }
+    } ();
+    
+    
+    std::cout << "----------------------------------" << std::endl;
+    std::cout << plume::Manager::state().getConfig() << std::endl;
+    std::cout << std::endl;
+    std::cout << plume::Manager::state() << std::endl;
+    std::cout << "----------------------------------" << std::endl;
+
+    const auto state = plume::Manager::state().getConfig();
+    auto tree        = state.getSubConfigurations("execution_tree");
+
+    EXPECT_EQUAL(state.getString("current"), "run_lvl5");
+    EXPECT_EQUAL(tree.size(), 5);
+    EXPECT_EQUAL(tree[0].getString("name"), "configure");
+    EXPECT_EQUAL(tree[0].getInt("iteration"), 1);
+    EXPECT_EQUAL(tree[0].getInt("iteration_relative"), 1);
+    EXPECT_EQUAL(tree[1].getString("name"), "negotiate");
+    EXPECT_EQUAL(tree[1].getInt("iteration"), 1);
+    EXPECT_EQUAL(tree[1].getInt("iteration_relative"), 1);
+    EXPECT_EQUAL(tree[2].getString("name"), "feed_plugins");
+    EXPECT_EQUAL(tree[2].getInt("iteration"), 1);
+    EXPECT_EQUAL(tree[2].getInt("iteration_relative"), 1);
+    EXPECT_EQUAL(tree[3].getString("name"), "run_lvl1");
+    EXPECT_EQUAL(tree[3].getInt("iteration"), 1);
+    EXPECT_EQUAL(tree[3].getInt("iteration_relative"), 1);
+    EXPECT_EQUAL(tree[4].getString("name"), "run_lvl2");
+    EXPECT_EQUAL(tree[4].getInt("iteration"), 3);
+    EXPECT_EQUAL(tree[4].getInt("iteration_relative"), 3);
+
+    auto innerChildren = tree[4].getSubConfigurations("children");
+    EXPECT_EQUAL(innerChildren.size(), 1);
+    EXPECT_EQUAL(innerChildren[0].getString("name"), "run_lvl3");
+    EXPECT_EQUAL(innerChildren[0].getInt("iteration"), 5);
+    EXPECT_EQUAL(innerChildren[0].getInt("iteration_relative"), 1);
+
+    auto level11Children = innerChildren[0].getSubConfigurations("children");
+    EXPECT_EQUAL(level11Children.size(), 2);
+    EXPECT_EQUAL(level11Children[0].getString("name"), "run_lvl4");
+    EXPECT_EQUAL(level11Children[0].getInt("iteration"), 10);
+    EXPECT_EQUAL(level11Children[0].getInt("iteration_relative"), 2);
+    EXPECT_EQUAL(level11Children[1].getString("name"), "run_lvl5");
+    EXPECT_EQUAL(level11Children[1].getInt("iteration"), 18);
+    EXPECT_EQUAL(level11Children[1].getInt("iteration_relative"), 2);
+
+    auto currentNode = state.getSubConfiguration("current_node");
+    EXPECT_EQUAL(currentNode.getString("name"), "run_lvl5");
+    EXPECT_EQUAL(currentNode.getInt("iteration"), 18);
+    EXPECT_EQUAL(currentNode.getInt("iteration_relative"), 2);
+
+    plume::Manager::teardown();
+    const auto finalState = plume::Manager::state().getConfig();
+    auto finalTree        = finalState.getSubConfigurations("execution_tree");
+    EXPECT_EQUAL(finalState.getString("current"), "teardown");
+
+    EXPECT_EQUAL(finalTree.size(), 6);
+    EXPECT_EQUAL(finalTree[5].getString("name"), "teardown");
+    EXPECT_EQUAL(finalTree[5].getInt("iteration"), 1);
+    EXPECT_EQUAL(finalTree[5].getInt("iteration_relative"), 1);
+
+    auto finalCurrentNode = finalState.getSubConfiguration("current_node");
+    EXPECT_EQUAL(finalCurrentNode.getString("name"), "teardown");
+    EXPECT_EQUAL(finalCurrentNode.getInt("iteration"), 1);
+    EXPECT_EQUAL(finalCurrentNode.getInt("iteration_relative"), 1);
+}
+
+
+CASE("test_manager_current_state_accessors") {
+    ManagerTestAccess::reset();
+
+    plume::Manager manager;
+    EXPECT_EQUAL(manager.currentStateName(), "");
+    EXPECT_EQUAL(manager.currentStateIteration(), 0);
+    EXPECT_EQUAL(manager.currentStateIterationRel(), 0);
+
+    std::string mgr_conf_str = R"YAML(
+    plugins:
+      - lib: simple_plugins
+        name: SimplePlugin
+        core-config: {}
+    )YAML";
+
+    eckit::YAMLConfiguration mgr_cfg(mgr_conf_str);
+
+    std::string data_conf_str = R"YAML(
+    offered:
+      - name: I
+        type: INT
+        available: always
+        comment: none-1
+      - name: J
+        type: INT
+        available: always
+        comment: none-2
+      - name: K
+        type: INT
+        available: always
+        comment: none-3
+    )YAML";
+
+    eckit::YAMLConfiguration data_cfg(data_conf_str);
+
+    plume::Manager::configure(mgr_cfg);
+    EXPECT_EQUAL(manager.currentStateName(), "configure");
+    EXPECT_EQUAL(manager.currentStateIteration(), 1);
+    EXPECT_EQUAL(manager.currentStateIterationRel(), 1);
+
+    plume::Manager::negotiate(data_cfg);
+    EXPECT_EQUAL(manager.currentStateName(), "negotiate");
+    EXPECT_EQUAL(manager.currentStateIteration(), 1);
+    EXPECT_EQUAL(manager.currentStateIterationRel(), 1);
+
+    plume::data::ModelData data;
+    data.createParam("I", 1);
+    data.createParam("J", 2);
+    data.createParam("K", 3);
+
+    plume::Manager::feedPlugins(data);
+    EXPECT_EQUAL(manager.currentStateName(), "feed_plugins");
+    EXPECT_EQUAL(manager.currentStateIteration(), 1);
+    EXPECT_EQUAL(manager.currentStateIterationRel(), 1);
+
+    plume::Manager::run(plume::PlumeTag::RUN_LVL1);
+    EXPECT_EQUAL(manager.currentStateName(), "run_lvl1");
+    EXPECT_EQUAL(manager.currentStateIteration(), 1);
+    EXPECT_EQUAL(manager.currentStateIterationRel(), 1);
+
+    plume::Manager::run(plume::PlumeTag::RUN_LVL1);
+    EXPECT_EQUAL(manager.currentStateName(), "run_lvl1");
+    EXPECT_EQUAL(manager.currentStateIteration(), 2);
+    EXPECT_EQUAL(manager.currentStateIterationRel(), 2);
+
+    plume::Manager::run(plume::PlumeTag::RUN_LVL2, plume::PlumeTag::RUN_LVL1);
+    EXPECT_EQUAL(manager.currentStateName(), "run_lvl2");
+    EXPECT_EQUAL(manager.currentStateIteration(), 1);
+    EXPECT_EQUAL(manager.currentStateIterationRel(), 1);
+
+    plume::Manager::run(plume::PlumeTag::RUN_LVL2, plume::PlumeTag::RUN_LVL1);
+    EXPECT_EQUAL(manager.currentStateName(), "run_lvl2");
+    EXPECT_EQUAL(manager.currentStateIteration(), 2);
+    EXPECT_EQUAL(manager.currentStateIterationRel(), 2);
+
+    // Incrementing the parent starts a new epoch for its children relative iterations.
+    plume::Manager::run(plume::PlumeTag::RUN_LVL1);
+    EXPECT_EQUAL(manager.currentStateName(), "run_lvl1");
+    EXPECT_EQUAL(manager.currentStateIteration(), 3);
+    EXPECT_EQUAL(manager.currentStateIterationRel(), 3);
+
+    plume::Manager::run(plume::PlumeTag::RUN_LVL2, plume::PlumeTag::RUN_LVL1);
+    EXPECT_EQUAL(manager.currentStateName(), "run_lvl2");
+    EXPECT_EQUAL(manager.currentStateIteration(), 3);
+    EXPECT_EQUAL(manager.currentStateIterationRel(), 1);
+
+    plume::Manager::teardown();
+    EXPECT_EQUAL(manager.currentStateName(), "teardown");
+    EXPECT_EQUAL(manager.currentStateIteration(), 1);
+    EXPECT_EQUAL(manager.currentStateIterationRel(), 1);
+}
+
+
+CASE("test_manager_rejects_ambiguous_parent_tags") {
+    ManagerTestAccess::reset();
+
+    std::string mgr_conf_str = R"YAML(
+    plugins:
+      - lib: simple_plugins
+        name: SimplePlugin
+        core-config: {}
+    )YAML";
+
+    eckit::YAMLConfiguration mgr_cfg(mgr_conf_str);
+
+    std::string data_conf_str = R"YAML(
+    offered:
+      - name: I
+        type: INT
+        available: always
+        comment: none-1
+      - name: J
+        type: INT
+        available: always
+        comment: none-2
+      - name: K
+        type: INT
+        available: always
+        comment: none-3
+    )YAML";
+
+    eckit::YAMLConfiguration data_cfg(data_conf_str);
+
+    plume::Manager::configure(mgr_cfg);
+    plume::Manager::negotiate(data_cfg);
+
+    plume::data::ModelData data;
+    data.createParam("I", 1);
+    data.createParam("J", 2);
+    data.createParam("K", 3);
+    plume::Manager::feedPlugins(data);
+
+    plume::Manager::run(plume::PlumeTag::RUN_LVL1);
+    plume::Manager::run(plume::PlumeTag::RUN_LVL3, plume::PlumeTag::RUN_LVL1);
+    plume::Manager::run(plume::PlumeTag::RUN_LVL2);
+    plume::Manager::run(plume::PlumeTag::RUN_LVL3, plume::PlumeTag::RUN_LVL2);
+
+    EXPECT_THROWS(plume::Manager::run(plume::PlumeTag::RUN_LVL4, plume::PlumeTag::RUN_LVL3));
+}
+
+
 //----------------------------------------------------------------------------------------------------------------------
 
 }  // namespace plume::test


### PR DESCRIPTION
### Description

This draft PR proposes tags in plume, to decorate the execution of manager methods and define a plume state. The state can be queried by plugins.

**Not for review yet - for discussion only**


### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/Contributor-License-Agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 
