### PR TITLE
PLUME-60: Writable model parameters negotiation

### DIFF
--- a/src/plume/CMakeLists.txt
+++ b/src/plume/CMakeLists.txt
@@ -83,6 +83,10 @@ set(PLUME_PLUGIN_MANAGER_SOURCES
     Configurable.h
     Configurable.cc
     PluginConfig.h
+    coupling/WriteBackPolicy.h
+    coupling/WriteBackPolicy.cc
+    coupling/WriteAuthorisation.h
+    coupling/WriteAuthorisation.cc
     data/ModelData.h
     data/ModelData.cc
     data/ParameterType.h

--- a/src/plume/Manager.cc
+++ b/src/plume/Manager.cc
@@ -12,8 +12,8 @@
 #include <algorithm>
 #include <cstdlib>
 #include <functional>
-#include <map>
 #include <memory>
+#include <vector>
 
 #include "eckit/config/LocalConfiguration.h"
 #include "eckit/exception/Exceptions.h"
@@ -104,6 +104,8 @@ std::optional<ManagerConfig> Manager::managerConfig_;
 
 bool Manager::isConfigured_{false};
 
+WriteAuthorisation Manager::writeAuthorisation_;
+
 
 void Manager::configure(const eckit::Configuration& config) {
     if (!Manager::isConfigured_) {
@@ -139,10 +141,11 @@ void Manager::negotiate(const Protocol& offers) {
     std::vector<std::string> names(pnames.begin(), pnames.end());
     eckit::Log::info() << "Plume config: " << *managerConfig_ << ", offers: " << names << std::endl;
 
-    // Negotiate with each plugin
-    Negotiator negotiator;
+    const WriteBackPolicy policy = managerConfig_.value().writeBackPolicy();
+    eckit::Log::info() << "Plume Write-back policy: " << policy << std::endl;
 
-    // Load all selected plugins as per configuration
+    Negotiator negotiator(policy);
+
     for (const auto& pconfig : managerConfig_.value().plugins()) {
 
         auto name = pconfig.name();
@@ -150,13 +153,9 @@ void Manager::negotiate(const Protocol& offers) {
 
         eckit::Log::info() << std::endl << " <== Evaluating Plugin: " << name << " from Library: " << lib << std::endl;
 
-        // Load the plugin
-        Plugin& plugin = loadPlugin(lib, name);
-
-        // check what each plugin requires
+        Plugin& plugin    = loadPlugin(lib, name);
         Protocol requires = plugin.negotiate();
 
-        // Check plugin parameters requested through configuration (if any)
         auto config_params = pconfig.parameters();
         if (config_params.size() > 0) {
             eckit::Log::info() << "Parameters from Config: " << config_params << std::endl;
@@ -165,15 +164,17 @@ void Manager::negotiate(const Protocol& offers) {
             eckit::Log::info() << "No additional parameters found in Config." << std::endl;
         }
 
-        // negotiator handles the negotiation
-        PluginDecision decision = negotiator.negotiate(offers, requires, config_params);
+        PluginDecision decision = negotiator.negotiate(name, offers, requires, config_params);
         eckit::Log::info() << decision << std::endl;
 
-        // If the plugin is accepted, set it as active
         if (decision.accepted()) {
             PluginRegistry::instance().setActive(plugin, pconfig, decision);
         }
     }
+
+    negotiator.logSummary();
+
+    writeAuthorisation_ = negotiator.writeAuthorisation();
 
     PluginRegistry::instance().setDataCatalogue(offers.offers());
 };
@@ -240,6 +241,15 @@ std::unordered_set<std::string> Manager::getActiveParams() {
 }
 
 
+std::vector<std::string> Manager::getActivePluginNames() {
+    std::vector<std::string> names;
+    for (const auto& handler : PluginRegistry::instance().getActivePlugins()) {
+        names.push_back(handler.pluginName());
+    }
+    return names;
+}
+
+
 data::ParameterCatalogue Manager::getActiveDataCatalogue() {
     return PluginRegistry::instance().getActiveDataCatalogue();
 }
@@ -258,6 +268,10 @@ bool Manager::isParamRequested(const std::string& name) {
 
 bool Manager::isConfigured() {
     return Manager::isConfigured_;
+}
+
+const WriteAuthorisation& Manager::writeAuthorisation() {
+    return writeAuthorisation_;
 }
 
 
@@ -281,6 +295,7 @@ void Manager::reset() {
     PluginRegistry::instance().reset();
     isConfigured_ = false;
     managerConfig_.reset();
+    writeAuthorisation_ = WriteAuthorisation{};
 }
 
 

--- a/src/plume/Manager.h
+++ b/src/plume/Manager.h
@@ -24,6 +24,7 @@
 #include "plume/ManagerConfig.h"
 #include "plume/Plugin.h"
 #include "plume/PluginDecision.h"
+#include "plume/coupling/WriteAuthorisation.h"
 #include "plume/data/ParameterCatalogue.h"
 #include "plume/data/ModelData.h"
 
@@ -50,10 +51,19 @@ public:
     static void configure(const eckit::Configuration& config);
 
     /**
-     * @brief Negotiate with Plugins
-     * 
-     * @param offers 
-     * @return
+     * @brief Negotiate with all candidate plugins listed in the manager configuration.
+     *
+     * For each plugin (in config order):
+     *   - Loads the plugin and retrieves its parameter requirements.
+     *   - Delegates per-plugin checks (version compatibility, parameter availability,
+     *     write-back policy gate) and cross-plugin conflict detection
+     *     (write-write, write-read, write-derived-read) to a Negotiator instance
+     *     constructed with the write-back policy from the manager config.
+     *   - Activates the plugin if the Negotiator accepts it.
+     *
+     * Emits a post-negotiation parameter-claim summary via Negotiator::logSummary().
+     *
+     * @param offers  Protocol describing the parameters offered by the model.
      */
     static void negotiate(const Protocol& offers);
 
@@ -86,6 +96,13 @@ public:
     static bool isPluginActivated(const std::string& name);
 
     /**
+     * @brief Ordered list of active plugin names, in the order they will run.
+     *
+     * @return std::vector<std::string>
+     */
+    static std::vector<std::string> getActivePluginNames();
+
+    /**
      * @brief List of Active Params
      * 
      * @return data::ParamList 
@@ -109,6 +126,18 @@ public:
     static bool isParamRequested(const std::string& name);
 
     static bool isConfigured();
+
+    /**
+     * @brief Write authorisation table produced by the last negotiate() call.
+     *
+     * Maps each accepted plugin name to the set of parameter names it has been granted write access to.
+     * Only plugins that explicitly requested writable access appear; read-only requesters are excluded.
+     * This table is used by Plume to enforce write-back policy at runtime.
+     *
+     * Returns a const reference — callers may query but not modify the authorisations.
+     * Must be called after negotiate() has completed.
+     */
+    static const WriteAuthorisation& writeAuthorisation();
 
 private:
 
@@ -136,6 +165,8 @@ private:
     static std::optional<ManagerConfig> managerConfig_;
 
     static bool isConfigured_;
+
+    static WriteAuthorisation writeAuthorisation_;
 
     friend struct test::ManagerTestAccess;
 

--- a/src/plume/ManagerConfig.h
+++ b/src/plume/ManagerConfig.h
@@ -12,6 +12,7 @@
 #pragma once
 
 #include "Configurable.h"
+#include "coupling/WriteBackPolicy.h"
 
 #include "eckit/config/LocalConfiguration.h"
 #include "eckit/config/YAMLConfiguration.h"
@@ -26,10 +27,16 @@ class ManagerConfig final : public CheckedConfigurable {
 public:
 
 ManagerConfig() : 
-    CheckedConfigurable{eckit::YAMLConfiguration(std::string("{\"plugins\":[]}")), {"plugins"}, {"verbose"}} {}
+    CheckedConfigurable{eckit::YAMLConfiguration(std::string("{\"plugins\":[]}")),
+                        {"plugins"}, {"verbose", "write-back-policy"}} {}
 
 ManagerConfig(const eckit::Configuration& config) : 
-    CheckedConfigurable{config, {"plugins"}, {"verbose"}} {
+    CheckedConfigurable{config, {"plugins"}, {"verbose", "write-back-policy"}} {
+
+    // Validate write-back-policy string early so errors are caught at configure() time.
+    if (this->config().isString("write-back-policy")) {
+        writeBackPolicyFromString(this->config().getString("write-back-policy"));
+    }
 
     // plugins must be a list
     if (!this->config().isSubConfigurationList("plugins")) {
@@ -64,6 +71,19 @@ std::vector<PluginConfig> plugins() const {
     }
 
     return pluginConfigs;
+}
+
+/**
+ * @brief Write-back policy for this manager instance.
+ *
+ * Returns WriteBackPolicy::disabled when the "write-back-policy" key is absent,
+ * ensuring existing model configurations that do not use write-back are unaffected.
+ * Throws eckit::BadValue if an unrecognised policy string is supplied.
+ *
+ * @return WriteBackPolicy
+ */
+WriteBackPolicy writeBackPolicy() const {
+    return writeBackPolicyFromString(config().getString("write-back-policy", "disabled"));
 }
 
 };

--- a/src/plume/Negotiator.cc
+++ b/src/plume/Negotiator.cc
@@ -10,6 +10,7 @@
  */
 
 #include <iostream>
+#include <map>
 #include <set>
 
 #include "plume/Negotiator.h"
@@ -17,6 +18,8 @@
 #include "plume/utils.h"
 
 namespace plume {
+
+Negotiator::Negotiator(WriteBackPolicy policy) : policy_{policy} {}
 
 bool Negotiator::isParamOffered(const Protocol& offers, const data::ParameterDefinition& param) {
     eckit::Log::info() << " - Considering Parameter: " << param.name() << std::endl;
@@ -36,11 +39,155 @@ bool Negotiator::isParamOffered(const Protocol& offers, const data::ParameterDef
             return false;
         }
     }
+
+    // If the plugin requests write access:
+    //   1. The write-back policy must permit it (not disabled).
+    //   2. The model must have explicitly offered the parameter as writable.
+    // Derived parameters cannot be writable (enforced at ParameterDefinition construction), so param.name()
+    // is always the name the model offered directly.
+    if (param.writable()) {
+        if (policy_ == WriteBackPolicy::disabled) {
+            eckit::Log::warning() << "Parameter \"" << param.name()
+                                  << "\" requested as writable but write-back is disabled "
+                                     "(set \"write-back-policy\" in manager config)."
+                                  << std::endl;
+            return false;
+        }
+        if (!offers.offers().getParam(param.name()).writable()) {
+            eckit::Log::warning() << "Parameter \"" << param.name()
+                                  << "\" requested as writable but not offered as writable!" << std::endl;
+            return false;
+        }
+    }
+
     return true;
 }
 
 
-PluginDecision Negotiator::negotiate(const Protocol& offers, const Protocol& requires,
+bool Negotiator::checkConflicts(const std::string& pluginName, const PluginDecision& decision) {
+    for (const auto& param : decision.offeredParams()) {
+        const std::string& pname  = param.name();
+        const std::string& source = param.sourceParam();  // non-empty only for derived params
+        const bool isDerived      = !source.empty();
+
+        if (param.writable()) {
+            // Write-Write conflict
+            if (writableClaimants_.count(pname) && !isMultiWriter(policy_)) {
+                eckit::Log::error()
+                    << "Plume negotiation: plugin \"" << pluginName
+                    << "\" rejected — write-write conflict: param \"" << pname
+                    << "\" already written by \"" << writableClaimants_[pname].front() << "\"." << std::endl;
+                return false;
+            }
+
+            if (isStrictPolicy(policy_)) {
+                // Write-Read conflict: existing readers
+                if (readonlyClaimants_.count(pname)) {
+                    eckit::Log::error()
+                        << "Plume negotiation: plugin \"" << pluginName
+                        << "\" rejected under strict policy — write-read conflict: "
+                        << "param \"" << pname << "\" is already read (read-only) by one or more plugins." << std::endl;
+                    return false;
+                }
+                // Write-DerivedRead conflict: existing derived readers
+                if (derivedClaimants_.count(pname)) {
+                    eckit::Log::error()
+                        << "Plume negotiation: plugin \"" << pluginName
+                        << "\" rejected under strict policy — write-derived-read conflict: "
+                        << "a derived version of param \"" << pname
+                        << "\" is already consumed by one or more plugins." << std::endl;
+                    return false;
+                }
+            }
+        }
+        else if (!isDerived) {
+            // Read-Write conflict: existing writer
+            if (writableClaimants_.count(pname) && isStrictPolicy(policy_)) {
+                eckit::Log::error()
+                    << "Plume negotiation: plugin \"" << pluginName
+                    << "\" rejected under strict policy — read-write conflict: "
+                    << "param \"" << pname << "\" is already written by \""
+                    << writableClaimants_[pname].front() << "\"." << std::endl;
+                return false;
+            }
+        }
+        else {
+            // DerivedRead-Write conflict: existing writer on source
+            if (writableClaimants_.count(source) && isStrictPolicy(policy_)) {
+                eckit::Log::error()
+                    << "Plume negotiation: plugin \"" << pluginName
+                    << "\" rejected under strict policy — derived-read-write conflict: "
+                    << "source param \"" << source << "\" of derived param \"" << pname
+                    << "\" is already written by \"" << writableClaimants_[source].front() << "\"." << std::endl;
+                return false;
+            }
+        }
+    }
+    return true;
+}
+
+
+void Negotiator::recordClaims(const std::string& pluginName, const PluginDecision& decision) {
+    executionOrder_.push_back({pluginName, {}});
+    auto& entry = executionOrder_.back();
+
+    for (const auto& param : decision.offeredParams()) {
+        const std::string& pname  = param.name();
+        const std::string& source = param.sourceParam();
+        if (param.writable()) {
+            writableClaimants_[pname].push_back(pluginName);
+        }
+        else if (source.empty()) {
+            readonlyClaimants_[pname].push_back(pluginName);
+        }
+        else {
+            derivedClaimants_[source].push_back(pluginName);
+        }
+        entry.params.push_back(param);
+    }
+}
+
+
+void Negotiator::logSummary() const {
+    if (executionOrder_.empty()) {
+        eckit::Log::info() << "Plume negotiation summary: no plugins accepted." << std::endl;
+        return;
+    }
+
+    eckit::Log::info() << "Plume negotiation summary — accepted plugin execution order:" << std::endl;
+    for (size_t i = 0; i < executionOrder_.size(); ++i) {
+        const auto& plugin = executionOrder_[i];
+        eckit::Log::info() << "  [" << (i + 1) << "] " << plugin.name << std::endl;
+        for (const auto& param : plugin.params) {
+            std::string mode;
+            if (param.writable()) {
+                mode = "write-back";
+            }
+            else if (!param.sourceParam().empty()) {
+                mode = "derived  (source: " + param.sourceParam() + ")";
+            }
+            else {
+                mode = "read-only";
+            }
+            eckit::Log::info() << "       - " << param.name() << "  (" << mode << ")" << std::endl;
+        }
+    }
+}
+
+
+WriteAuthorisation Negotiator::writeAuthorisation() const {
+    WriteAuthorisation auth;
+    for (const auto& [paramName, plugins] : writableClaimants_) {
+        for (const auto& pluginName : plugins) {
+            auth.grant(pluginName, paramName);
+        }
+    }
+    return auth;
+}
+
+
+PluginDecision Negotiator::negotiate(const std::string& pluginName, const Protocol& offers,
+                                     const Protocol& requires,
                                      const std::vector<eckit::LocalConfiguration>& config_params) {
 
     eckit::Log::info() << "Requesting Plume Version: " << LibVersion(requires.requiredPlumeVersion()).asString()
@@ -59,7 +206,23 @@ PluginDecision Negotiator::negotiate(const Protocol& offers, const Protocol& req
         return PluginDecision{false};
     }
 
-    std::set<data::ParameterDefinition> allRequestedParams;
+    // Accumulate requested params in a map keyed by name.
+    // "Writable wins": if the same param is requested read-only from code and writable from a
+    // config group (or vice versa), the writable version takes precedence so that write-back
+    // intent is never silently lost.  Using std::set<ParameterDefinition> directly would drop
+    // the second insert because operator< compares by name only, causing the writable flag to be
+    // determined solely by whichever version was inserted first.
+    std::map<std::string, data::ParameterDefinition> paramMap;
+    auto insertOrUpgrade = [&paramMap](const data::ParameterDefinition& p) {
+        auto it = paramMap.find(p.name());
+        if (it == paramMap.end()) {
+            paramMap.emplace(p.name(), p);
+        }
+        else if (p.writable() && !it->second.writable()) {
+            it->second = p;  // upgrade to writable
+        }
+    };
+
     std::set<std::string> requested_param_names = requires.requiredParamNames();
     std::vector<data::ParameterDefinition> requested_params = requires.requires().getParams();
 
@@ -80,7 +243,7 @@ PluginDecision Negotiator::negotiate(const Protocol& offers, const Protocol& req
     }
 
     if (!requested_params.empty()) {
-        allRequestedParams.insert(requested_params.begin(), requested_params.end());
+        for (const auto& p : requested_params) { insertOrUpgrade(p); }
     }
 
     // 2) Check requested parameters (from the configuration)
@@ -111,8 +274,8 @@ PluginDecision Negotiator::negotiate(const Protocol& offers, const Protocol& req
                 eckit::Log::info() << " ---> Parameter Group Accepted!" << std::endl;
                 any_group_accepted = true;
 
-                // add all parameters in the group to the set "allRequestedParams"
-                allRequestedParams.insert(requested_params.begin(), requested_params.end());
+                // add all parameters in the group to paramMap with writable-wins semantics
+                for (const auto& p : requested_params) { insertOrUpgrade(p); }
             }
             else {
                 eckit::Log::warning() << "---> Group rejected!" << std::endl;
@@ -124,8 +287,19 @@ PluginDecision Negotiator::negotiate(const Protocol& offers, const Protocol& req
         }
     }
 
-    return PluginDecision(true, allRequestedParams);
-};
+    // Convert paramMap to the set expected by PluginDecision (unique by name, writable-wins applied).
+    std::set<data::ParameterDefinition> allRequestedParams;
+    for (const auto& [name, param] : paramMap) { allRequestedParams.insert(param); }
+
+    // 3) Cross-plugin conflict detection (stateful: checks against previously accepted plugins)
+    PluginDecision decision(true, allRequestedParams);
+    if (!checkConflicts(pluginName, decision)) {
+        return PluginDecision{false};
+    }
+
+    recordClaims(pluginName, decision);
+    return decision;
+}
 
 
 }  // namespace plume

--- a/src/plume/Negotiator.h
+++ b/src/plume/Negotiator.h
@@ -11,10 +11,16 @@
 
 #pragma once
 
+#include <map>
+#include <string>
+#include <vector>
+
 #include "eckit/config/LocalConfiguration.h"
 
 #include "PluginDecision.h"
 #include "Protocol.h"
+#include "coupling/WriteAuthorisation.h"
+#include "coupling/WriteBackPolicy.h"
 #include "data/ParameterCatalogue.h"
 
 
@@ -22,19 +28,73 @@ namespace plume {
 
 class Negotiator {
 private:
+    WriteBackPolicy policy_;
+
+    // Cross-plugin state: accumulated across negotiate() calls (config order = run order).
+    std::map<std::string, std::vector<std::string>> writableClaimants_;   // param -> writers
+    std::map<std::string, std::vector<std::string>> readonlyClaimants_;   // param -> readers
+    std::map<std::string, std::vector<std::string>> derivedClaimants_;    // source param -> derived-readers
+
+    // Execution order: accepted plugins in config order, each with their accepted params.
+    struct AcceptedPlugin {
+        std::string name;
+        std::vector<data::ParameterDefinition> params;
+    };
+    std::vector<AcceptedPlugin> executionOrder_;
+
     bool isParamOffered(const Protocol& offers, const data::ParameterDefinition& param);
+
+    // Check cross-plugin conflicts for an accepted single-plugin decision.
+    // Returns true if the plugin should be activated; false if it must be rejected.
+    bool checkConflicts(const std::string& pluginName, const PluginDecision& decision);
+
+    // Record the accepted plugin's parameter claims into the tracking maps.
+    void recordClaims(const std::string& pluginName, const PluginDecision& decision);
 
 public:
     /**
-     * @brief Negotiate with a plugin
+     * @brief Construct a Negotiator with the given write-back policy.
      *
-     * @param requires
-     * @param config_params
-     * @return PluginDecision
+     * @param policy  Controls whether plugins may request writable parameters.
+     *                Defaults to WriteBackPolicy::disabled — no write-back allowed.
+     */
+    explicit Negotiator(WriteBackPolicy policy = WriteBackPolicy::disabled);
+
+    /**
+     * @brief Negotiate with a single plugin (per-plugin checks + cross-plugin conflict detection).
+     *
+     * Per-plugin checks (stateless): version compatibility, parameter availability, writable policy gate.
+     * Cross-plugin checks (stateful): write-write, write-read and write-derived-read conflicts.
+     * If accepted, the plugin's claims are recorded for future calls.
+     *
+     * @param pluginName   Name of the plugin being negotiated (used in log messages and claim maps).
+     * @param offers       Parameters offered by the model.
+     * @param requires     Parameters required by the plugin.
+     * @param config_params Optional parameter groups from manager configuration.
+     * @return PluginDecision with accepted=true if the plugin passes all checks.
      */
     PluginDecision negotiate(
+        const std::string& pluginName,
         const Protocol& offers, const Protocol& requires,
         const std::vector<eckit::LocalConfiguration>& config_params = std::vector<eckit::LocalConfiguration>{});
+
+    /**
+     * @brief Emit a post-negotiation summary of the accepted plugin execution order.
+     *
+     * For each accepted plugin in run order, logs each parameter it will use and
+     * its access mode: "write-back", "read-only", or "derived (source: X)".
+     * Should be called once after all plugins have been negotiated.
+     */
+    void logSummary() const;
+
+    /**
+     * @brief Build and return the write authorisation table for the completed negotiation.
+     *
+     * Returns a WriteAuthorisation mapping each accepted plugin name to the set of parameter names it has been granted
+     * write access to. Only plugins that explicitly requested write access (writable: true) appear; read-only
+     * requesters are excluded. Must be called after all negotiate() calls are complete.
+     */
+    WriteAuthorisation writeAuthorisation() const;
 };
 
 

--- a/src/plume/Protocol.h
+++ b/src/plume/Protocol.h
@@ -71,6 +71,18 @@ public:
     }
 
     /**
+     * @brief Lets plugins require write access to a parameter.
+     *
+     * The negotiator will reject the plugin if the model has not offered the parameter as writable.
+     */
+    template <typename T>
+    void requireWritable(const std::string& name) {
+        insertParam(data::ParameterDefinition(name, data::deduceType<T>(), /*avail=*/"", /*comment=*/"",
+                                              /*writable=*/true),
+                    requiredParams_);
+    }
+
+    /**
      * @brief Lets plugins require params derived from model parameters in their negotiate method.
      */
     template <typename T>
@@ -91,8 +103,8 @@ public:
     void offerAtlasVersion(const std::string& version);
 
     template <typename T>
-    void offer(const std::string& name, const std::string& avail, const std::string& comment) {
-        insertParam(data::ParameterDefinition(name, data::deduceType<T>(), avail, comment), offeredParams_);
+    void offer(const std::string& name, const std::string& avail, const std::string& comment, bool writable = false) {
+        insertParam(data::ParameterDefinition(name, data::deduceType<T>(), avail, comment, writable), offeredParams_);
     }
 
     std::set<std::string> offeredParamNames() const;

--- a/src/plume/api/plume.cc
+++ b/src/plume/api/plume.cc
@@ -208,6 +208,42 @@ int plume_protocol_offer_atlas_field(plume_protocol_handle_t* h, const char* nam
     });
 }
 
+int plume_protocol_offer_int_writable(plume_protocol_handle_t* h, const char* name, const char* avail, const char* comment) {
+    return wrapApiFunction([h, name, avail, comment] {
+        ASSERT(h);
+        ASSERT((h)->impl_);
+        h->impl_->offer<int>(name, avail, comment, /*writable=*/true);
+    });
+}
+int plume_protocol_offer_bool_writable(plume_protocol_handle_t* h, const char* name, const char* avail, const char* comment) {
+    return wrapApiFunction([h, name, avail, comment] {
+        ASSERT(h);
+        ASSERT((h)->impl_);
+        h->impl_->offer<bool>(name, avail, comment, /*writable=*/true);
+    });
+}
+int plume_protocol_offer_float_writable(plume_protocol_handle_t* h, const char* name, const char* avail, const char* comment) {
+    return wrapApiFunction([h, name, avail, comment] {
+        ASSERT(h);
+        ASSERT((h)->impl_);
+        h->impl_->offer<float>(name, avail, comment, /*writable=*/true);
+    });
+}
+int plume_protocol_offer_double_writable(plume_protocol_handle_t* h, const char* name, const char* avail, const char* comment) {
+    return wrapApiFunction([h, name, avail, comment] {
+        ASSERT(h);
+        ASSERT((h)->impl_);
+        h->impl_->offer<double>(name, avail, comment, /*writable=*/true);
+    });
+}
+int plume_protocol_offer_atlas_field_writable(plume_protocol_handle_t* h, const char* name, const char* avail, const char* comment) {
+    return wrapApiFunction([h, name, avail, comment] {
+        ASSERT(h);
+        ASSERT((h)->impl_);
+        h->impl_->offer<atlas::Field>(name, avail, comment, /*writable=*/true);
+    });
+}
+
 int plume_protocol_delete_handle(plume_protocol_handle_t* h) {
     return wrapApiFunction([&h] {
         if (h) {

--- a/src/plume/api/plume.h
+++ b/src/plume/api/plume.h
@@ -100,6 +100,14 @@ int plume_protocol_offer_bool(plume_protocol_handle_t* h, const char* name, cons
 int plume_protocol_offer_float(plume_protocol_handle_t* h, const char* name, const char* avail, const char* comment);
 int plume_protocol_offer_double(plume_protocol_handle_t* h, const char* name, const char* avail, const char* comment);
 int plume_protocol_offer_atlas_field(plume_protocol_handle_t* h, const char* name, const char* avail, const char* comment);
+
+/* Writable-offer variants: the model declares that plugins may write back to these parameters. */
+int plume_protocol_offer_int_writable(plume_protocol_handle_t* h, const char* name, const char* avail, const char* comment);
+int plume_protocol_offer_bool_writable(plume_protocol_handle_t* h, const char* name, const char* avail, const char* comment);
+int plume_protocol_offer_float_writable(plume_protocol_handle_t* h, const char* name, const char* avail, const char* comment);
+int plume_protocol_offer_double_writable(plume_protocol_handle_t* h, const char* name, const char* avail, const char* comment);
+int plume_protocol_offer_atlas_field_writable(plume_protocol_handle_t* h, const char* name, const char* avail, const char* comment);
+
 int plume_protocol_delete_handle(plume_protocol_handle_t* h);
 
 /* --- Plume Manager --- */

--- a/src/plume/api/plume_protocol.F90
+++ b/src/plume/api/plume_protocol.F90
@@ -29,6 +29,12 @@ module plume_protocol_module
         procedure :: offer_double       => plume_protocol_offer_double
         procedure :: offer_atlas_field  => plume_protocol_offer_atlas_field
 
+        procedure :: offer_int_writable         => plume_protocol_offer_int_writable
+        procedure :: offer_bool_writable        => plume_protocol_offer_bool_writable
+        procedure :: offer_float_writable       => plume_protocol_offer_float_writable
+        procedure :: offer_double_writable      => plume_protocol_offer_double_writable
+        procedure :: offer_atlas_field_writable => plume_protocol_offer_atlas_field_writable
+
         procedure :: finalise           => plume_protocol_delete_handle
     end type
     
@@ -100,6 +106,56 @@ module plume_protocol_module
         integer(c_int) :: err
     end function    
 
+    function plume_protocol_offer_int_writable_interf( handle_impl, name, avail, comment ) result(err) &
+        & bind(C,name="plume_protocol_offer_int_writable")
+        use iso_c_binding, only: c_ptr, c_char, c_int
+        type(c_ptr), intent(in), value :: handle_impl
+        character(c_char), dimension(*) :: name
+        character(c_char), dimension(*) :: avail
+        character(c_char), dimension(*) :: comment
+        integer(c_int) :: err
+    end function
+
+    function plume_protocol_offer_bool_writable_interf( handle_impl, name, avail, comment ) result(err) &
+        & bind(C,name="plume_protocol_offer_bool_writable")
+        use iso_c_binding, only: c_ptr, c_char, c_int
+        type(c_ptr), intent(in), value :: handle_impl
+        character(c_char), dimension(*) :: name
+        character(c_char), dimension(*) :: avail
+        character(c_char), dimension(*) :: comment
+        integer(c_int) :: err
+    end function
+
+    function plume_protocol_offer_float_writable_interf( handle_impl, name, avail, comment ) result(err) &
+        & bind(C,name="plume_protocol_offer_float_writable")
+        use iso_c_binding, only: c_ptr, c_char, c_int
+        type(c_ptr), intent(in), value :: handle_impl
+        character(c_char), dimension(*) :: name
+        character(c_char), dimension(*) :: avail
+        character(c_char), dimension(*) :: comment
+        integer(c_int) :: err
+    end function
+
+    function plume_protocol_offer_double_writable_interf( handle_impl, name, avail, comment ) result(err) &
+        & bind(C,name="plume_protocol_offer_double_writable")
+        use iso_c_binding, only: c_ptr, c_char, c_int
+        type(c_ptr), intent(in), value :: handle_impl
+        character(c_char), dimension(*) :: name
+        character(c_char), dimension(*) :: avail
+        character(c_char), dimension(*) :: comment
+        integer(c_int) :: err
+    end function
+
+    function plume_protocol_offer_atlas_field_writable_interf( handle_impl, name, avail, comment ) result(err) &
+        & bind(C,name="plume_protocol_offer_atlas_field_writable")
+        use iso_c_binding, only: c_ptr, c_char, c_int
+        type(c_ptr), intent(in), value :: handle_impl
+        character(c_char), dimension(*) :: name
+        character(c_char), dimension(*) :: avail
+        character(c_char), dimension(*) :: comment
+        integer(c_int) :: err
+    end function
+
     end interface
 
 
@@ -161,6 +217,56 @@ module plume_protocol_module
         integer(c_int) :: err
         err = plume_protocol_offer_atlas_field_interf(handle%impl, c_str(name), c_str(avail), c_str(comment) )
     end function    
+
+    function plume_protocol_offer_int_writable( handle, name, avail, comment ) result(err)
+        use iso_c_binding, only: c_ptr, c_char, c_int
+        class(plume_protocol), intent(inout) :: handle
+        character(kind=c_char,len=*), intent(in) :: name
+        character(kind=c_char,len=*), intent(in) :: avail
+        character(kind=c_char,len=*), intent(in) :: comment
+        integer(c_int) :: err
+        err = plume_protocol_offer_int_writable_interf(handle%impl, c_str(name), c_str(avail), c_str(comment) )
+    end function
+
+    function plume_protocol_offer_bool_writable( handle, name, avail, comment ) result(err)
+        use iso_c_binding, only: c_ptr, c_char, c_int
+        class(plume_protocol), intent(inout) :: handle
+        character(kind=c_char,len=*), intent(in) :: name
+        character(kind=c_char,len=*), intent(in) :: avail
+        character(kind=c_char,len=*), intent(in) :: comment
+        integer(c_int) :: err
+        err = plume_protocol_offer_bool_writable_interf(handle%impl, c_str(name), c_str(avail), c_str(comment) )
+    end function
+
+    function plume_protocol_offer_float_writable( handle, name, avail, comment ) result(err)
+        use iso_c_binding, only: c_ptr, c_char, c_int
+        class(plume_protocol), intent(inout) :: handle
+        character(kind=c_char,len=*), intent(in) :: name
+        character(kind=c_char,len=*), intent(in) :: avail
+        character(kind=c_char,len=*), intent(in) :: comment
+        integer(c_int) :: err
+        err = plume_protocol_offer_float_writable_interf(handle%impl, c_str(name), c_str(avail), c_str(comment) )
+    end function
+
+    function plume_protocol_offer_double_writable( handle, name, avail, comment ) result(err)
+        use iso_c_binding, only: c_ptr, c_char, c_int
+        class(plume_protocol), intent(inout) :: handle
+        character(kind=c_char,len=*), intent(in) :: name
+        character(kind=c_char,len=*), intent(in) :: avail
+        character(kind=c_char,len=*), intent(in) :: comment
+        integer(c_int) :: err
+        err = plume_protocol_offer_double_writable_interf(handle%impl, c_str(name), c_str(avail), c_str(comment) )
+    end function
+
+    function plume_protocol_offer_atlas_field_writable( handle, name, avail, comment ) result(err)
+        use iso_c_binding, only: c_ptr, c_char, c_int
+        class(plume_protocol), intent(inout) :: handle
+        character(kind=c_char,len=*), intent(in) :: name
+        character(kind=c_char,len=*), intent(in) :: avail
+        character(kind=c_char,len=*), intent(in) :: comment
+        integer(c_int) :: err
+        err = plume_protocol_offer_atlas_field_writable_interf(handle%impl, c_str(name), c_str(avail), c_str(comment) )
+    end function
 
     function plume_protocol_delete_handle( handle ) result(err)
       class(plume_protocol), intent(inout) :: handle

--- a/src/plume/coupling/README.md
+++ b/src/plume/coupling/README.md
@@ -1,0 +1,191 @@
+# Plume Write-Back Policy Reference
+
+Plume write-back (two-way coupling) feature allows plugins to modify model parameters and return
+values to the model. Because this is a sensitive capability with implications for
+model correctness and reproducibility, it is **disabled by default** and must be
+explicitly enabled via the `write-back-policy` key in the manager configuration.
+
+---
+
+## Configuration
+
+```yaml
+write-back-policy: single-writer   # or: single-writer-strict | multi-writer | multi-writer-strict | disabled
+plugins:
+  - lib: my_plugin_lib
+    name: MyPlugin
+    parameters:
+      -
+        - name: TEMP
+          type: FLOAT
+          writable: true     # this plugin requests write access to TEMP
+    core-config: {}
+```
+
+If `write-back-policy` is absent, the default is **`disabled`**: any plugin that
+requests a writable parameter is rejected at negotiation time. This ensures that
+existing model configurations that do not use write-back are unaffected. This can also be enforced from the model side for model-owned parameters, by providing all parameters in read-only mode.
+
+---
+
+## Interaction Types
+
+Three types of cross-plugin interaction become relevant once write-back is enabled:
+
+In all cases **run order is determined by the order plugins appear in the
+manager config** (first listed = first run). Plume logs the run order so you can reason about what each plugin will observe at runtime.
+
+---
+
+## Policies
+
+### `disabled` (default)
+
+No write-back is permitted, all plugins are one-way coupled (read-only) with the model. Any plugin requesting a writable parameter is
+rejected at negotiation before it can be activated.
+
+---
+
+### `single-writer`
+
+At most **one writer** per parameter. A second writer is rejected.
+
+A reader (read-only) or derived-reader of a written parameter is **allowed**;
+the run order is logged so the user can reason about what value they will observe:
+
+**Run-order semantics for case Write-Read:**
+
+- Writer runs **before** reader → reader sees the **written value**.
+- Reader runs **before** writer → reader sees the **original model value**.
+
+**Run-order semantics for Write-DerivedRead:**
+
+- Writer runs **before** derived-reader → derived param is created from the **written value**.
+- Derived-reader runs **before** writer → derived param is created from the **original model value**.
+
+---
+
+### `single-writer-strict`
+
+At most **one writer** per parameter. A second writer is rejected.
+
+Readers and derived-readers of a written parameter are also **rejected**
+(the writer has exclusive access to the parameter — no other plugin may consume it).
+
+Use this when you need guaranteed isolation — once a writer is accepted, no
+other plugin may consume the same parameter (as a base or derived read).
+
+> **Order sensitivity:** rejection is applied to whichever plugin arrives second
+> in the config.  If a reader is listed before a writer, it is the **writer**
+> that is rejected.  Place the plugin you want to keep first in the `plugins`
+> list to guarantee it survives strict-mode negotiation.
+
+---
+
+### `multi-writer`
+
+**Multiple writers** per parameter are allowed. All writers are accepted;
+a `WARNING` with the full run order is logged after negotiation.
+
+Readers and derived-readers of a written parameter are **allowed**; run order
+is logged.
+
+Use this when multiple plugins legitimately need to modify the same parameter
+(e.g. a pipeline of post-processing stages at different entry points within the same model step), and you accept last-write-wins
+semantics.
+
+---
+
+### `multi-writer-strict`
+
+**Multiple writers** per parameter are allowed.
+
+Readers and derived-readers of any written parameter are **rejected**
+(writers collectively have exclusive use of the parameter).
+
+> **Order sensitivity:** the plugin listed second in the config is rejected when
+> a write-read or write-derived-read conflict is detected.  If a reader is
+> listed before a writer, it is the **writer** that gets rejected.
+
+---
+
+## Policy Summary Table
+
+| Policy | Write-Write | Write-Read | Write-DerivedRead |
+|---|---|---|---|
+| `disabled` | N/A (all writable requests rejected) | N/A | N/A |
+| `single-writer` | 2nd writer **rejected** | Allowed, **run order logged** | Allowed, **run order logged** |
+| `single-writer-strict` | 2nd writer **rejected** | 2nd plugin **rejected** | 2nd plugin **rejected** |
+| `multi-writer` | All allowed, **run order logged** | Allowed, **run order logged** | Allowed, **run order logged** |
+| `multi-writer-strict` | All allowed, **run order logged** | 2nd plugin **rejected** | 2nd plugin **rejected** |
+
+"2nd plugin" refers to the plugin that **creates the conflict**, i.e. the later
+entry in the manager config, regardless of whether that plugin is the writer or
+the reader.
+
+> **Order matters in strict mode.**  Rejection is always applied to the plugin
+> that arrives second in the negotiation loop (= second in the `plugins` config
+> list).  If the reader is listed before the writer, it is the **writer** that
+> gets rejected, not the reader.  If you want a guaranteed outcome, place the
+> plugin you want to keep first in the config.
+
+---
+
+## Run-Order Guarantee
+
+Plugin activation order, and therefore run order, is **deterministic**: it
+follows the order plugins appear in the `plugins` list of the manager config.
+
+```yaml
+plugins:
+  - name: PluginA   # runs 1st
+  - name: PluginB   # runs 2nd
+  - name: PluginC   # runs 3rd
+```
+
+Plume logs the run order for every interaction involving a writable parameter so
+the user can inspect the Plume log output and understand what each plugin will
+observe.
+
+---
+
+## FAQ
+
+**Why is `disabled` the default?**
+Write-back is a sensitive feature that can affect model state. Requiring an
+explicit opt-in via `write-back-policy` ensures that existing configurations are
+not silently affected by plugins that happen to declare writable parameters.
+
+**Can I use `writable: true` in the model's offers even under `disabled`?**
+Yes. The model is free to declare which parameters *could* be writable in its
+protocol offers. The `write-back-policy` only controls whether plugins are
+*permitted* to request write access at negotiation time. A writable offer under
+`disabled` will never result in a plugin being granted write access.
+
+**What happens to a derived parameter when its source is modified?**
+Derived parameters (e.g. `u;hl;100` derived from `u`) are computed from the
+source parameter's value at the time the derived param is first requested during
+`feedPlugins`. If a writer modifies the source *after* a derived-reader has
+already set up its derived param, the derived-reader will see the original value.
+The `Write-DerivedRead` warnings tell you exactly this ordering.
+
+**Can derived parameters themselves be writable?**
+No. Derived parameters update their value through an _update strategy_ (e.g.
+interpolating from a base field to a specific level/height). Because the strategy
+is the sole source of truth for the derived value, write-back to a derived
+parameter would be immediately overwritten on the next strategy update, making it
+meaningless. Plume therefore enforces this constraint at two levels:
+
+1. **YAML config path** — `ParameterCatalogue` throws `eckit::BadParameter` at
+   construction if a parameter definition carries both strategy options
+   (`height`, etc.) and `writable: true`.
+
+2. **C++ API path** — `Protocol::requireWritable<T>(name)` accepts only a bare
+   parameter name and has no overload that also accepts strategy options. It is
+   therefore impossible to construct a derived+writable `ParameterDefinition`
+   through the plugin API. Passing a derived-looking name (e.g. `"u;hl;100"`)
+   to `requireWritable` produces a non-derived definition, which is then
+   rejected at negotiation because the model never offers `"u;hl;100"` as a
+   base parameter.
+
+Only base (non-derived) parameters support write-back.

--- a/src/plume/coupling/WriteAuthorisation.cc
+++ b/src/plume/coupling/WriteAuthorisation.cc
@@ -1,0 +1,45 @@
+/*
+ * (C) Copyright 2023- ECMWF.
+ *
+ * This software is licensed under the terms of the Apache Licence Version 2.0
+ * which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * In applying this licence, ECMWF does not waive the privileges and immunities
+ * granted to it by virtue of its status as an intergovernmental organisation nor
+ * does it submit to any jurisdiction.
+ */
+#include "plume/coupling/WriteAuthorisation.h"
+
+namespace plume {
+
+const std::set<std::string> WriteAuthorisation::kEmptySet_{};
+
+void WriteAuthorisation::grant(const std::string& pluginName, const std::string& paramName) {
+    authorisations_[pluginName].insert(paramName);
+}
+
+bool WriteAuthorisation::isAuthorised(const std::string& pluginName, const std::string& paramName) const {
+    auto it = authorisations_.find(pluginName);
+    if (it == authorisations_.end()) {
+        return false;
+    }
+    return it->second.count(paramName) > 0;
+}
+
+const std::set<std::string>& WriteAuthorisation::authorisedParams(const std::string& pluginName) const {
+    auto it = authorisations_.find(pluginName);
+    if (it == authorisations_.end()) {
+        return kEmptySet_;
+    }
+    return it->second;
+}
+
+std::set<std::string> WriteAuthorisation::authorisedPlugins() const {
+    std::set<std::string> result;
+    for (const auto& [name, params] : authorisations_) {
+        result.insert(result.end(), name);
+    }
+    return result;
+}
+
+}  // namespace plume

--- a/src/plume/coupling/WriteAuthorisation.h
+++ b/src/plume/coupling/WriteAuthorisation.h
@@ -1,0 +1,63 @@
+/*
+ * (C) Copyright 2023- ECMWF.
+ *
+ * This software is licensed under the terms of the Apache Licence Version 2.0
+ * which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * In applying this licence, ECMWF does not waive the privileges and immunities
+ * granted to it by virtue of its status as an intergovernmental organisation nor
+ * does it submit to any jurisdiction.
+ */
+#pragma once
+
+#include <map>
+#include <set>
+#include <string>
+
+namespace plume {
+
+/**
+ * @brief Records which plugins are authorised to write back which parameters, as determined during negotiation.
+ *
+ * Populated by the Negotiator after all plugins have been negotiated and stored by the Manager.
+ * This class is used by Plume to enforce write-back policy at plugin run phase.
+ */
+class WriteAuthorisation {
+private:
+    /// pluginName -> set of parameter names the plugin is authorised to write.
+    std::map<std::string, std::set<std::string>> authorisations_;
+
+    static const std::set<std::string> kEmptySet_;
+
+public:
+    WriteAuthorisation() = default;
+
+    /**
+     * @brief Grant pluginName write access to paramName.
+     *
+     * Called internally by the Negotiator; not intended for direct use
+     * by model or plugin code.
+     */
+    void grant(const std::string& pluginName, const std::string& paramName);
+
+    /**
+     * @brief Returns true if the plugin was granted write access to the named parameter.
+     */
+    bool isAuthorised(const std::string& pluginName, const std::string& paramName) const;
+
+    /**
+     * @brief Returns the set of parameter names the plugin may write.
+     *
+     * Returns a reference to an empty set if the plugin has no write authorisations.
+     */
+    const std::set<std::string>& authorisedParams(const std::string& pluginName) const;
+
+    /**
+     * @brief Returns all plugin names that have at least one write authorisation.
+     */
+    std::set<std::string> authorisedPlugins() const;
+
+    bool empty() const { return authorisations_.empty(); }
+};
+
+}  // namespace plume

--- a/src/plume/coupling/WriteBackPolicy.cc
+++ b/src/plume/coupling/WriteBackPolicy.cc
@@ -1,0 +1,42 @@
+/*
+ * (C) Copyright 2023- ECMWF.
+ *
+ * This software is licensed under the terms of the Apache Licence Version 2.0
+ * which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * In applying this licence, ECMWF does not waive the privileges and immunities
+ * granted to it by virtue of its status as an intergovernmental organisation nor
+ * does it submit to any jurisdiction.
+ */
+
+#include "plume/coupling/WriteBackPolicy.h"
+
+#include "eckit/exception/Exceptions.h"
+
+namespace plume {
+
+WriteBackPolicy writeBackPolicyFromString(const std::string& str) {
+    if (str == "disabled")              return WriteBackPolicy::disabled;
+    if (str == "single-writer")         return WriteBackPolicy::single_writer;
+    if (str == "single-writer-strict")  return WriteBackPolicy::single_writer_strict;
+    if (str == "multi-writer")          return WriteBackPolicy::multi_writer;
+    if (str == "multi-writer-strict")   return WriteBackPolicy::multi_writer_strict;
+    throw eckit::BadValue(
+        "Unknown write-back-policy \"" + str + "\". "
+        "Valid values are: \"disabled\", \"single-writer\", \"single-writer-strict\", "
+        "\"multi-writer\", \"multi-writer-strict\".",
+        Here());
+}
+
+std::ostream& operator<<(std::ostream& os, WriteBackPolicy policy) {
+    switch (policy) {
+        case WriteBackPolicy::disabled:             return os << "disabled";
+        case WriteBackPolicy::single_writer:        return os << "single-writer";
+        case WriteBackPolicy::single_writer_strict: return os << "single-writer-strict";
+        case WriteBackPolicy::multi_writer:         return os << "multi-writer";
+        case WriteBackPolicy::multi_writer_strict:  return os << "multi-writer-strict";
+    }
+    throw eckit::BadValue("Unknown WriteBackPolicy enum value", Here());
+}
+
+}  // namespace plume

--- a/src/plume/coupling/WriteBackPolicy.h
+++ b/src/plume/coupling/WriteBackPolicy.h
@@ -1,0 +1,79 @@
+/*
+ * (C) Copyright 2023- ECMWF.
+ *
+ * This software is licensed under the terms of the Apache Licence Version 2.0
+ * which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * In applying this licence, ECMWF does not waive the privileges and immunities
+ * granted to it by virtue of its status as an intergovernmental organisation nor
+ * does it submit to any jurisdiction.
+ */
+
+#pragma once
+
+#include <cstdint>
+#include <ostream>
+#include <string>
+
+namespace plume {
+
+/**
+ * @brief Policy governing whether and how plugins may write back to model parameters.
+ *
+ * Rejection in strict mode always applies to the plugin that arrives second in the
+ * negotiation loop (= second in the manager config `plugins` list), regardless of
+ * whether that plugin is the writer or the reader.  Place the plugin you want to
+ * keep first in the config list to guarantee it survives strict-mode negotiation.
+ *
+ * disabled                (default)
+ *   No plugin may request write access to any parameter.
+ *
+ * single_writer           ("single-writer")
+ *   At most one writer per param. A second writer is rejected.
+ *   Readers and derived-readers of a written param are ALLOWED; run order is
+ *   logged so the user can reason about what value they will observe.
+ *
+ * single_writer_strict    ("single-writer-strict")
+ *   At most one writer per param. A second writer is rejected.
+ *   The plugin that creates a write-read or write-derived-read conflict is also
+ *   REJECTED (whichever of the writer or the reader appears second in the config).
+ *
+ * multi_writer            ("multi-writer")
+ *   Multiple writers per param are allowed; run order is logged.
+ *   Readers and derived-readers of a written param are ALLOWED; run order is logged.
+ *
+ * multi_writer_strict     ("multi-writer-strict")
+ *   Multiple writers per param are allowed; run order is logged.
+ *   The plugin that creates a write-read or write-derived-read conflict is
+ *   REJECTED (whichever of the writer or the reader appears second in the config).
+ *
+ * See README for the full policy reference.
+ */
+enum class WriteBackPolicy : uint8_t {
+    disabled             = 0,
+    single_writer        = 1,
+    single_writer_strict = 2,
+    multi_writer         = 3,
+    multi_writer_strict  = 4,
+};
+
+WriteBackPolicy writeBackPolicyFromString(const std::string& str);
+
+std::ostream& operator<<(std::ostream& os, WriteBackPolicy policy);
+
+/// Returns true for any policy that permits write-back (i.e. not disabled).
+inline bool isWriteBackEnabled(WriteBackPolicy p) {
+    return p != WriteBackPolicy::disabled;
+}
+
+/// Returns true for strict policies that reject coexistence of same param readers and writers.
+inline bool isStrictPolicy(WriteBackPolicy p) {
+    return p == WriteBackPolicy::single_writer_strict || p == WriteBackPolicy::multi_writer_strict;
+}
+
+/// Returns true for policies that allow more than one writer per param.
+inline bool isMultiWriter(WriteBackPolicy p) {
+    return p == WriteBackPolicy::multi_writer || p == WriteBackPolicy::multi_writer_strict;
+}
+
+}  // namespace plume

--- a/src/plume/data/ParameterCatalogue.cc
+++ b/src/plume/data/ParameterCatalogue.cc
@@ -28,6 +28,7 @@ ParameterDefinition::ParameterDefinition(const eckit::Configuration& config) :
     dataType_  = typeFromString(config.getString("type").c_str());
     available_ = config.getString("available", "on-request");
     comment_   = config.getString("comment", "");
+    writable_  = config.getBool("writable", false);
 
     // determine strategy, dependencies & derived param name based on the config, if applicable
     bool hasOptions = false;
@@ -43,6 +44,13 @@ ParameterDefinition::ParameterDefinition(const eckit::Configuration& config) :
 
         if (strategy.empty()) {
             throw eckit::BadParameter("No strategy matches the options passed for param '" + name_ + "'!", Here());
+        }
+
+        if (writable_) {
+            throw eckit::BadParameter(
+                "Derived parameter '" + name_ + "' cannot be declared writable. "
+                "Only base (non-derived) parameters support write-back.",
+                Here());
         }
 
         sourceParam_  = name_;
@@ -61,12 +69,12 @@ ParameterDefinition::ParameterDefinition(const eckit::Configuration& config) :
 
 // construct from params
 ParameterDefinition::ParameterDefinition(const std::string& name, const std::string& type, const std::string& available,
-                                         const std::string& comment) :
-    ParameterDefinition{params2config(name, type, available, comment)} {}
+                                         const std::string& comment, bool writable) :
+    ParameterDefinition{params2config(name, type, available, comment, writable)} {}
 
 ParameterDefinition::ParameterDefinition(const std::string& name, const ParameterType& type,
-                                         const std::string& available, const std::string& comment) :
-    ParameterDefinition{params2config(name, typeToString(type), available, comment)} {}
+                                         const std::string& available, const std::string& comment, bool writable) :
+    ParameterDefinition{params2config(name, typeToString(type), available, comment, writable)} {}
 
 ParameterDefinition::ParameterDefinition(const std::string& name, const ParameterType& type,
                                          const std::unordered_map<std::string, std::string>& options) :
@@ -114,14 +122,20 @@ const std::vector<std::string>& ParameterDefinition::dependencies() const {
     return dependencies_;
 }
 
+bool ParameterDefinition::writable() const {
+    return writable_;
+}
+
 // helper constructing function
 eckit::LocalConfiguration ParameterDefinition::params2config(const std::string& name, const std::string& type,
-                                                             const std::string& available, const std::string& comment) {
+                                                             const std::string& available, const std::string& comment,
+                                                             bool writable) {
     eckit::LocalConfiguration config;
     config.set("name", name);
     config.set("type", type);
     config.set("available", available);
     config.set("comment", comment);
+    config.set("writable", writable);
     return config;
 }
 

--- a/src/plume/data/ParameterCatalogue.h
+++ b/src/plume/data/ParameterCatalogue.h
@@ -47,6 +47,7 @@ private:
     std::string strategy_;                   ///< Optional, strategy name, deduced from above options.
     std::string sourceParam_;                ///< Optional, original param that this param derives from.
     std::vector<std::string> dependencies_;  ///< Optional, based on the strategy requirements.
+    bool writable_ = false;                  ///< Whether plugins are permitted to write back to this parameter.
 
     /// All params must have a set of options which can be referred to here to avoid hardcoding in the constructors.
     inline static const std::unordered_set<std::string> essentialKeys_ = {"name", "type"};
@@ -56,7 +57,7 @@ private:
      * All params are allowed a set of options which can be referred to here to avoid hardcoding in the constructors.
      */
     inline static const std::unordered_set<std::string> optionalKeys_ = []() {
-        std::unordered_set<std::string> keys = {"available", "comment", "levtype", "level"};
+        std::unordered_set<std::string> keys = {"available", "comment", "levtype", "level", "writable"};
         for (const auto& key : field_provider::UpdateStrategyTraits<int>::allConfigArgs) {
             keys.insert(std::string(key));
         }
@@ -64,7 +65,8 @@ private:
     }();
 
     eckit::LocalConfiguration params2config(const std::string& name, const std::string& type,
-                                            const std::string& available = "", const std::string& comment = "");
+                                            const std::string& available = "", const std::string& comment = "",
+                                            bool writable = false);
 
 public:
     /** 
@@ -72,9 +74,9 @@ public:
      */
     ParameterDefinition(const eckit::Configuration& config);
     ParameterDefinition(const std::string& name, const std::string& type, const std::string& available = "",
-                        const std::string& comment = "");
+                        const std::string& comment = "", bool writable = false);
     ParameterDefinition(const std::string& name, const ParameterType& type, const std::string& available = "",
-                        const std::string& comment = "");
+                        const std::string& comment = "", bool writable = false);
     ParameterDefinition(const std::string& name, const ParameterType& type,
                         const std::unordered_map<std::string, std::string>& options);
 
@@ -92,6 +94,7 @@ public:
     const std::string& strategy() const;
     const std::string& sourceParam() const;
     const std::vector<std::string>& dependencies() const;
+    bool writable() const;
 };
 
 

--- a/tests/api/test_params_api.F90
+++ b/tests/api/test_params_api.F90
@@ -38,15 +38,15 @@ character(len=1000) :: mgr_conf_str
 
 logical(c_bool) :: is_requested
 
-character(len=4) :: param_names_requested(5)
-character(len=4) :: param_names_rejected(4)
+character(len=6) :: param_names_requested(6)
+character(len=6) :: param_names_rejected(5)
 integer :: i_param
 
 
 call atlas_library%initialise()
 call plume_check(plume_initialise())
 
-! make offers
+! make offers (read-only params)
 call plume_check(offers%initialise())
 call plume_check(offers%offer_int("I", "always", "this is param I"))
 call plume_check(offers%offer_int("J", "always", "this is param J"))
@@ -54,9 +54,15 @@ call plume_check(offers%offer_float("FF1", "always", "this is param FF1"))
 call plume_check(offers%offer_double("DD1", "always", "this is param DD1"))
 call plume_check(offers%offer_atlas_field("AA1", "always", "this is param AA1"))
 
+! make offers (writable params)
+! W_INT is offered as writable; W_RO is offered as read-only
+call plume_check(offers%offer_int_writable("W_INT", "always", "writable int param"))
+call plume_check(offers%offer_int("W_RO", "always", "read-only int param"))
+
 
 ! negotiate
 mgr_conf_str = '{' // &
+'"write-back-policy": "single-writer", ' // &
 '"plugins": [ ' // &
 '    { ' // &
 '        "lib": "plume_plugin_test_api", ' // &
@@ -77,6 +83,12 @@ mgr_conf_str = '{' // &
 '            [ ' // &
 '                {"name":"XYZ", "type":"INT"}, ' // &
 '                {"name":"K", "type":"INT"} ' // &
+'            ], ' // &
+'            [ ' // &
+'                {"name":"W_INT", "type":"INT", "writable": true} ' // &
+'            ], ' // &
+'            [ ' // &
+'                {"name":"W_RO", "type":"INT", "writable": true} ' // &
 '            ] ' // &
 '        ], ' // &
 '        "core-config": {} ' // &
@@ -89,16 +101,18 @@ call plume_check(manager%initialise())
 call plume_check(manager%configure_from_string(trim(mgr_conf_str)))
 call plume_check(manager%negotiate(offers))
 
-! check accepted parameters
-param_names_requested = [ character(len=4) :: "I", "J", "FF1", "DD1", "AA1" ]
+! check accepted parameters (existing + writable W_INT)
+param_names_requested = [ character(len=6) :: "I", "J", "FF1", "DD1", "AA1", "W_INT" ]
 do i_param=1,size(param_names_requested)
     is_requested = .false.
     call plume_check(manager%is_param_requested(trim(param_names_requested(i_param)), is_requested))
     FCTEST_CHECK(is_requested)
 end do
 
-! check rejected parameters
-param_names_rejected = [ character(len=4) :: "JJJ", "KKMM", "XYZ", "K" ]
+! check rejected parameters:
+!   - JJJ, KKMM, XYZ, K: not offered
+!   - W_RO: offered read-only but plugin required it as writable -> group rejected
+param_names_rejected = [ character(len=6) :: "JJJ", "KKMM", "XYZ", "K", "W_RO" ]
 do i_param=1,size(param_names_rejected)
     is_requested = .true.
     call plume_check(manager%is_param_requested(trim(param_names_rejected(i_param)), is_requested))

--- a/tests/core/test_catalogue.cc
+++ b/tests/core/test_catalogue.cc
@@ -73,6 +73,62 @@ CASE("test catalogue") {
 
 }
 
+CASE("test writable parameter definition") {
+
+    // constructors with explicit writable flag
+    plume::data::ParameterDefinition writable_param("p", "INT", "always", "comment", /*writable=*/true);
+    EXPECT_EQUAL(writable_param.writable(), true);
+
+    plume::data::ParameterDefinition readonly_param("p", "INT", "always", "comment");
+    EXPECT_EQUAL(readonly_param.writable(), false);
+
+    // YAML config with writable: true
+    eckit::YAMLConfiguration writable_config(std::string(R"YAML(
+    name: param-w
+    type: INT
+    available: always
+    comment: writable param
+    writable: true
+    )YAML"));
+    plume::data::ParameterDefinition from_yaml_writable{writable_config};
+    EXPECT_EQUAL(from_yaml_writable.writable(), true);
+
+    // YAML config without writable key defaults to false
+    eckit::YAMLConfiguration readonly_config(std::string(R"YAML(
+    name: param-r
+    type: INT
+    available: always
+    comment: read-only param
+    )YAML"));
+    plume::data::ParameterDefinition from_yaml_readonly{readonly_config};
+    EXPECT_EQUAL(from_yaml_readonly.writable(), false);
+}
+
+
+CASE("test derived parameter cannot be writable") {
+
+    // Requesting a derived param (with level options) as writable must throw at construction.
+    eckit::YAMLConfiguration derived_writable_config(std::string(R"YAML(
+    name: u
+    type: ATLAS_FIELD
+    height: 100
+    writable: true
+    )YAML"));
+
+    EXPECT_THROWS(plume::data::ParameterDefinition bad{derived_writable_config});
+
+    // A derived param without writable is fine.
+    eckit::YAMLConfiguration derived_readonly_config(std::string(R"YAML(
+    name: u
+    type: ATLAS_FIELD
+    height: 100
+    )YAML"));
+
+    plume::data::ParameterDefinition derived_readonly{derived_readonly_config};
+    EXPECT_EQUAL(derived_readonly.writable(), false);
+}
+
+
 CASE("test empty catalogue + insert") {
 
     // insert params to empty catalogue

--- a/tests/core/test_negotiator.cc
+++ b/tests/core/test_negotiator.cc
@@ -8,11 +8,12 @@
  * granted to it by virtue of its status as an intergovernmental organisation nor
  * does it submit to any jurisdiction.
  */
-#include "eckit/testing/Test.h"
 #include "eckit/config/YAMLConfiguration.h"
-
+#include "eckit/testing/Test.h"
 
 #include "plume/Negotiator.h"
+#include "plume/coupling/WriteAuthorisation.h"
+#include "plume/coupling/WriteBackPolicy.h"
 #include "plume/data/ParameterCatalogue.h"
 
 
@@ -21,93 +22,286 @@ using namespace plume;
 
 namespace plume::test {
 
-CASE("test_negotiator ") {
+// =================================================================================================
+// Test helpers
+// =================================================================================================
+
+// Fluent builder for single-key YAML parameter lists (offered: / required:).
+// Usage:
+//   ParamListBuilder("offered").add("I", "INT").add("J", "INT", true)
+//   ParamListBuilder("required").add("I", "INT")
+struct ParamListBuilder {
+    explicit ParamListBuilder(const std::string& key) : yaml_{key + ":\n"} {}
+
+    ParamListBuilder& add(const std::string& name, const std::string& type, bool writable = false) {
+        yaml_ += "  - name: " + name + "\n";
+        yaml_ += "    type: " + type + "\n";
+        yaml_ += "    available: always\n";
+        if (writable)
+            yaml_ += "    writable: true\n";
+        return *this;
+    }
+
+    // Implicit conversion so the builder can be passed wherever std::string is expected.
+    operator std::string() const { return yaml_; }
+
+    // Convenience: build an eckit::YAMLConfiguration directly.
+    eckit::YAMLConfiguration cfg() const { return eckit::YAMLConfiguration(yaml_); }
+
+private:
+    std::string yaml_;
+};
+
+// Fluent builder for the "parameters:" YAML block used in manager config_params.
+// Each call to group(...) adds one parameter group (list of params).
+// Usage:
+//   ConfigGroupBuilder().group({{"I","INT",true}}).group({{"J","INT",false}})
+struct ParamEntry {
+    std::string name, type;
+    bool writable = false;
+};
+
+struct ConfigGroupBuilder {
+    std::string yaml_{"parameters:\n"};
+
+    ConfigGroupBuilder& group(std::initializer_list<ParamEntry> params) {
+        yaml_ += "  -\n";
+        for (const auto& p : params) {
+            yaml_ += "    - name: " + p.name + "\n";
+            yaml_ += "      type: " + p.type + "\n";
+            if (p.writable)
+                yaml_ += "      writable: true\n";
+        }
+        return *this;
+    }
+
+    // Parse and return the sub-configurations ready to pass to Negotiator::negotiate().
+    std::vector<eckit::LocalConfiguration> parse() const {
+        return eckit::YAMLConfiguration(yaml_).getSubConfigurations("parameters");
+    }
+};
+
+// Return the writable flag for a named param in a PluginDecision, or nullopt if not found.
+static std::optional<bool> decisionParamWritable(const PluginDecision& decision, const std::string& name) {
+    for (const auto& param : decision.offeredParams()) {
+        if (param.name() == name)
+            return param.writable();
+    }
+    return std::nullopt;
+}
+
+// Shared offers: I writable, J read-only — used across writable and authorisation tests.
+static const std::string kOffersIWritableJRO = ParamListBuilder("offered").add("I", "INT", true).add("J", "INT");
+
+// =================================================================================================
+// Tests
+// =================================================================================================
+
+CASE("test_negotiator - basic accept / reject / invalid-key") {
 
     Negotiator negotiator;
 
-    std::string offers_str = R"YAML(
-    offered:
-      - name: I
-        type: INT
-        available: always
-        comment: none-1
-      - name: J
-        type: INT
-        available: always
-        comment: none-2
-      - name: K
-        type: INT
-        available: always
-        comment: none-3
-    )YAML";
+    auto offers = ParamListBuilder("offered").add("I", "INT").add("J", "INT").add("K", "INT");
+    auto
+        requires
+    = ParamListBuilder("required").add("I", "INT").add("J", "INT").add("K", "INT");
+    auto requires_not_fulfilled = ParamListBuilder("required")
+                                      .add("I", "INT")
+                                      .add("J", "INT")
+                                      .add("K", "INT")
+                                      .add("K_new", "INT")
+                                      .add("K_new2", "INT");
 
-    std::string requires_str = R"YAML(
-    required:
-      - name: I
-        type: INT
-        available: always
-        comment: none-1
-      - name: J
-        type: INT
-        available: always
-        comment: none-2
-      - name: K
-        type: INT
-        available: always
-        comment: none-3
-    )YAML";
-
-    std::string requires_not_fullfilled_str = R"YAML(
-    required:
-      - name: I
-        type: INT
-        available: always
-        comment: none-1
-      - name: J
-        type: INT
-        available: always
-        comment: none-2
-      - name: K
-        type: INT
-        available: always
-        comment: none-3
-      - name: K_new
-        type: INT
-        available: always
-        comment: none-3
-      - name: K_new2
-        type: INT
-        available: always
-        comment: none-3
-    )YAML";
-
-    std::string requires_invalid_str = R"YAML(
+    // Manually-built invalid-key YAML (cannot be expressed via the builder).
+    const std::string requires_invalid_str = R"YAML(
     required_invalid_key:
       - name: I
         type: INT
         available: always
-        comment: none-1
-      - name: J
-        type: INT
-        available: always
-        comment: none-2
-      - name: K
-        type: INT
-        available: always
-        comment: none-3
     )YAML";
 
-    // negotiate                                        
-    PluginDecision decision = negotiator.negotiate(eckit::YAMLConfiguration(offers_str), eckit::YAMLConfiguration(requires_str));
+    EXPECT_EQUAL(negotiator.negotiate("TestPlugin", offers.cfg(), requires.cfg()).accepted(), true);
+    EXPECT_EQUAL(negotiator.negotiate("TestPlugin", offers.cfg(), requires_not_fulfilled.cfg()).accepted(), false);
+    EXPECT_THROWS(negotiator.negotiate("TestPlugin", offers.cfg(), eckit::YAMLConfiguration(requires_invalid_str)));
+}
+
+
+CASE("test_negotiator - writable params") {
+    // Write-back must be explicitly enabled; single_writer tests the offer-side gate.
+    Negotiator negotiator(WriteBackPolicy::single_writer);
+
+    auto offers = ParamListBuilder("offered").add("I", "INT", true).add("J", "INT");
+
+    // I offered as writable -> writable request accepted
+    auto requires_writable_ok = ParamListBuilder("required").add("I", "INT", true);
+    EXPECT_EQUAL(negotiator.negotiate("PluginA", offers.cfg(), requires_writable_ok.cfg()).accepted(), true);
+
+    // J not offered as writable -> writable request rejected
+    auto requires_writable_rejected = ParamListBuilder("required").add("J", "INT", true);
+    EXPECT_EQUAL(negotiator.negotiate("PluginA", offers.cfg(), requires_writable_rejected.cfg()).accepted(), false);
+
+    // I offered as writable, but plugin requests read-only -> accepted
+    auto requires_readonly = ParamListBuilder("required").add("I", "INT");
+    EXPECT_EQUAL(negotiator.negotiate("PluginA", offers.cfg(), requires_readonly.cfg()).accepted(), true);
+}
+
+
+CASE("test_negotiator - write-back disabled by default") {
+    Negotiator negotiator;  // policy = disabled
+
+    auto offers       = ParamListBuilder("offered").add("I", "INT", true);
+    auto req_writable = ParamListBuilder("required").add("I", "INT", true);
+    auto req_ro       = ParamListBuilder("required").add("I", "INT");
+
+    // Disabled policy rejects writable requests even when the model offers them.
+    EXPECT_EQUAL(negotiator.negotiate("TestPlugin", offers.cfg(), req_writable.cfg()).accepted(), false);
+    // Read-only is unaffected by write-back policy.
+    EXPECT_EQUAL(negotiator.negotiate("TestPlugin", offers.cfg(), req_ro.cfg()).accepted(), true);
+}
+
+
+CASE("test_negotiator - read-only code require + writable config request upgrades to writable") {
+    // ParameterDefinition::operator< compares by name only, so std::set::insert silently
+    // drops a writable entry if a read-only entry with the same name already exists.
+    
+    // Scenario (edge): plugin code requires I read-only; config group requests I writable.
+    // The final PluginDecision must mark I as writable.
+    // The paramMap + insertOrUpgrade ensure writable wins regardless of insertion order.
+    Negotiator negotiator(WriteBackPolicy::single_writer);
+
+    auto offers = ParamListBuilder("offered").add("I", "INT", true);
+    auto req_ro = ParamListBuilder("required").add("I", "INT");
+    auto cfg_w  = ConfigGroupBuilder().group({{"I", "INT", true}}).parse();
+
+    PluginDecision decision = negotiator.negotiate("PluginA", offers.cfg(), req_ro.cfg(), cfg_w);
     EXPECT_EQUAL(decision.accepted(), true);
 
-    // requests not fullfilled
-    PluginDecision decision_not_fullfilled = negotiator.negotiate(eckit::YAMLConfiguration(offers_str), eckit::YAMLConfiguration(requires_not_fullfilled_str));
-    EXPECT_EQUAL(decision_not_fullfilled.accepted(), false);
+    // I must be writable — config group's writable request must not be lost to insertion order.
+    auto writable = decisionParamWritable(decision, "I");
+    EXPECT(writable.has_value());
+    EXPECT_EQUAL(*writable, true);
+}
 
-    // invalid key
-    EXPECT_THROWS(negotiator.negotiate(eckit::YAMLConfiguration(offers_str), eckit::YAMLConfiguration(requires_invalid_str)));
 
+CASE("test_negotiator - writable code require + read-only config request stays writable") {
+    // Complementary direction: code=writable, config=RO -> writable must be preserved.
+    Negotiator negotiator(WriteBackPolicy::single_writer);
+
+    auto offers = ParamListBuilder("offered").add("I", "INT", true);
+    auto req_w  = ParamListBuilder("required").add("I", "INT", true);
+    auto cfg_ro = ConfigGroupBuilder().group({{"I", "INT"}}).parse();
+
+    PluginDecision decision = negotiator.negotiate("PluginA", offers.cfg(), req_w.cfg(), cfg_ro);
+    EXPECT_EQUAL(decision.accepted(), true);
+
+    auto writable = decisionParamWritable(decision, "I");
+    EXPECT(writable.has_value());
+    EXPECT_EQUAL(*writable, true);
+}
+
+
+CASE("test_negotiator - derived param cannot be writable") {
+    // Requesting a derived param as writable must throw at ParameterDefinition construction.
+    eckit::YAMLConfiguration derived_writable_requires(std::string(R"YAML(
+    required:
+      - name: u
+        type: ATLAS_FIELD
+        height: 100
+        writable: true
+    )YAML"));
+
+    EXPECT_THROWS(Protocol bad_protocol(derived_writable_requires));
+}
+
+
+// =================================================================================================
+// Write authorisation tests
+// =================================================================================================
+
+CASE("test_negotiator - write authorisation: pure read-only plugin is not authorised to write") {
+    // A plugin requesting I read-only must NOT appear in write authorisation,
+    // even though I is offered as writable by the model.
+    Negotiator negotiator(WriteBackPolicy::single_writer);
+
+    auto req_ro   = ParamListBuilder("required").add("I", "INT");
+    auto decision = negotiator.negotiate("PluginRO", eckit::YAMLConfiguration(kOffersIWritableJRO), req_ro.cfg());
+    EXPECT_EQUAL(decision.accepted(), true);
+
+    WriteAuthorisation auth = negotiator.writeAuthorisation();
+    EXPECT_EQUAL(auth.isAuthorised("PluginRO", "I"), false);
+    EXPECT(auth.empty());
+}
+
+
+CASE("test_negotiator - write authorisation: writable plugin is authorised") {
+    // A plugin requesting I as writable must appear in write authorisation.
+    Negotiator negotiator(WriteBackPolicy::single_writer);
+
+    auto req_w    = ParamListBuilder("required").add("I", "INT", true);
+    auto decision = negotiator.negotiate("PluginW", eckit::YAMLConfiguration(kOffersIWritableJRO), req_w.cfg());
+    EXPECT_EQUAL(decision.accepted(), true);
+
+    WriteAuthorisation auth = negotiator.writeAuthorisation();
+    EXPECT_EQUAL(auth.isAuthorised("PluginW", "I"), true);
+    EXPECT_EQUAL(auth.isAuthorised("PluginW", "J"), false);  // J was not requested
+
+    auto plugins = auth.authorisedPlugins();
+    EXPECT_EQUAL(plugins.size(), 1u);
+    EXPECT(plugins.count("PluginW") == 1);
+}
+
+
+CASE("test_negotiator - write authorisation: RO+RO combo does not grant write access") {
+    // Critical safety test: code=RO, config=RO -> writable-wins merge must NOT promote to writable.
+    Negotiator negotiator(WriteBackPolicy::single_writer);
+
+    auto req_ro = ParamListBuilder("required").add("I", "INT");
+    auto cfg_ro = ConfigGroupBuilder().group({{"I", "INT"}}).parse();
+
+    auto decision =
+        negotiator.negotiate("PluginROx2", eckit::YAMLConfiguration(kOffersIWritableJRO), req_ro.cfg(), cfg_ro);
+    EXPECT_EQUAL(decision.accepted(), true);
+
+    WriteAuthorisation auth = negotiator.writeAuthorisation();
+    EXPECT_EQUAL(auth.isAuthorised("PluginROx2", "I"), false);
+    EXPECT(auth.empty());
+}
+
+
+CASE("test_negotiator - write authorisation: writable-wins RO+writable grants write access") {
+    // code=RO, config=writable -> writable-wins upgrade is reflected in authorisation.
+    Negotiator negotiator(WriteBackPolicy::single_writer);
+
+    auto req_ro = ParamListBuilder("required").add("I", "INT");
+    auto cfg_w  = ConfigGroupBuilder().group({{"I", "INT", true}}).parse();
+
+    auto decision =
+        negotiator.negotiate("PluginUpgraded", eckit::YAMLConfiguration(kOffersIWritableJRO), req_ro.cfg(), cfg_w);
+    EXPECT_EQUAL(decision.accepted(), true);
+
+    WriteAuthorisation auth = negotiator.writeAuthorisation();
+    EXPECT_EQUAL(auth.isAuthorised("PluginUpgraded", "I"), true);
+}
+
+
+CASE("test_negotiator - write authorisation: only the writing plugin is authorised across two plugins") {
+    // Plugin A writes I, Plugin B reads I -> under multi_writer both accepted; only A authorised.
+    Negotiator negotiator(WriteBackPolicy::multi_writer);
+
+    auto req_w  = ParamListBuilder("required").add("I", "INT", true);
+    auto req_ro = ParamListBuilder("required").add("I", "INT");
+    auto offers = eckit::YAMLConfiguration(kOffersIWritableJRO);
+
+    EXPECT_EQUAL(negotiator.negotiate("PluginA", offers, req_w.cfg()).accepted(), true);
+    EXPECT_EQUAL(negotiator.negotiate("PluginB", offers, req_ro.cfg()).accepted(), true);
+
+    WriteAuthorisation auth = negotiator.writeAuthorisation();
+    EXPECT_EQUAL(auth.isAuthorised("PluginA", "I"), true);
+    EXPECT_EQUAL(auth.isAuthorised("PluginB", "I"), false);
+
+    auto plugins = auth.authorisedPlugins();
+    EXPECT_EQUAL(plugins.size(), 1u);
+    EXPECT(plugins.count("PluginA") == 1);
 }
 
 

--- a/tests/core/test_plugin_params.cc
+++ b/tests/core/test_plugin_params.cc
@@ -20,6 +20,129 @@ using namespace eckit::testing;
 
 namespace plume::test {
 
+// === Data offer builder ==========================================================================
+// Fluent builder for the "offered:" YAML block used in negotiate() calls.
+// Method chaining lets each variant be expressed as a one-liner starting from
+// the shared IJK base, with no repeated YAML boilerplate.
+
+struct OfferBuilder {
+    std::string yaml_{"offered:\n"};
+
+    OfferBuilder& add(const std::string& name, const std::string& type, bool writable = false) {
+        yaml_ += "  - name: " + name + "\n";
+        yaml_ += "    type: " + type + "\n";
+        yaml_ += "    available: always\n";
+        yaml_ += "    comment: none\n";
+        if (writable)
+            yaml_ += "    writable: true\n";
+        return *this;
+    }
+
+    // Implicit conversion so an OfferBuilder can be passed wherever a std::string is expected.
+    operator std::string() const { return yaml_; }
+};
+
+// Base factory: the three INT params hard-required by SimplePlugin::negotiate().
+static OfferBuilder offersIJK() {
+    return OfferBuilder{}.add("I", "INT").add("J", "INT").add("K", "INT");
+}
+
+// === Shared data offer configurations ============================================================
+
+// I, J, K only
+static const std::string kOffersIJK = offersIJK();
+// I, J, K + u  (z absent → u;hl;100 derivation cannot be satisfied)
+static const std::string kOffersIJKU = offersIJK().add("u", "ATLAS_FIELD");
+// I, J, K + u + z  (z is the geopotential dependency for u;hl;100 derivation)
+static const std::string kOffersIJKUZ = offersIJK().add("u", "ATLAS_FIELD").add("z", "ATLAS_FIELD");
+// I, J, K + W_INT (offered as writable)
+static const std::string kOffersIJKWritableInt = offersIJK().add("W_INT", "INT", /*writable=*/true);
+// I, J, K + W_RO (offered read-only)
+static const std::string kOffersIJKReadonlyInt = offersIJK().add("W_RO", "INT");
+// I, J, K + u + z + W_INT (writable) — multi-plugin write-back conflict tests
+static const std::string kOffersIJKUZWritableInt =
+    offersIJK().add("u", "ATLAS_FIELD").add("z", "ATLAS_FIELD").add("W_INT", "INT", true);
+// I, J, K + u (writable) + z — write-derived-read interaction tests
+static const std::string kOffersIJKWritableAtlas =
+    offersIJK().add("u", "ATLAS_FIELD", /*writable=*/true).add("z", "ATLAS_FIELD");
+
+// === Shared manager config builders ==============================================================
+
+// Two plugins both requesting W_INT as writable; only the policy varies.
+static std::string mgrBothWriteWInt(const std::string& policy) {
+    return "write-back-policy: " + policy + R"YAML(
+plugins:
+- lib: simple_plugins
+  name: SimplePlugin
+  parameters:
+    -
+      - name: W_INT
+        type: INT
+        writable: true
+  core-config: {}
+- lib: simple_plugins
+  name: SimpleDerivedPlugin
+  parameters:
+    -
+      - name: W_INT
+        type: INT
+        writable: true
+  core-config: {}
+)YAML";
+}
+
+// Writer (SimplePlugin, W_INT writable) + reader (SimpleDerivedPlugin, W_INT read-only).
+static std::string mgrWriteReadWInt(const std::string& policy) {
+    return "write-back-policy: " + policy + R"YAML(
+plugins:
+- lib: simple_plugins
+  name: SimplePlugin
+  parameters:
+    -
+      - name: W_INT
+        type: INT
+        writable: true
+  core-config: {}
+- lib: simple_plugins
+  name: SimpleDerivedPlugin
+  parameters:
+    -
+      - name: W_INT
+        type: INT
+  core-config: {}
+)YAML";
+}
+
+// Writer (SimplePlugin, u:ATLAS_FIELD writable) + derived-reader (SimpleDerivedPlugin, u;hl;100).
+static std::string mgrWriteUDerived(const std::string& policy) {
+    return "write-back-policy: " + policy + R"YAML(
+plugins:
+- lib: simple_plugins
+  name: SimplePlugin
+  parameters:
+    -
+      - name: u
+        type: ATLAS_FIELD
+        writable: true
+  core-config: {}
+- lib: simple_plugins
+  name: SimpleDerivedPlugin
+  core-config: {}
+)YAML";
+}
+
+// === Test helper =================================================================================
+
+// Reset Manager state, assert unconfigured, configure, then negotiate.
+// Asserts that both configure and negotiate do not throw.
+static void resetConfigureNegotiate(const std::string& mgrConf, const std::string& dataConf) {
+    ManagerTestAccess::reset();
+    EXPECT_NOT(plume::Manager::isConfigured());
+    EXPECT_NO_THROW(plume::Manager::configure(eckit::YAMLConfiguration(mgrConf)));
+    EXPECT_NO_THROW(plume::Manager::negotiate(eckit::YAMLConfiguration(dataConf)));
+}
+
+//--------------------------------------------------------------------------------------------------
 
 CASE("test_invalid_plugin_configuration_parameters") {
 
@@ -45,25 +168,6 @@ CASE("test_invalid_plugin_configuration_parameters") {
     )YAML";
 
     eckit::YAMLConfiguration mgr_cfg_invalid_param_type(mgr_conf_str2);
-
-    // protocol from config
-    std::string data_conf_str = R"YAML(
-    offered:
-    - name: I
-      type: INT
-      available: always
-      comment: none-1
-    - name: J
-      type: INT
-      available: always
-      comment: none-2
-    - name: K
-      type: INT
-      available: always
-      comment: none-3
-    )YAML";
-
-    eckit::YAMLConfiguration data_cfg(data_conf_str);
 
     // configure
     EXPECT_EQUAL(plume::Manager::isConfigured(), false);
@@ -99,8 +203,7 @@ CASE("test_valid_plugin_configuration_parameters") {
       core-config: {}
     )YAML";
 
-    eckit::YAMLConfiguration mgr_cfg_valid_json(mgr_conf_str);
-
+    // unique data config — this test exercises groups with non-standard params
     std::string data_conf_str = R"YAML(
     offered:
       - name: I
@@ -125,30 +228,21 @@ CASE("test_valid_plugin_configuration_parameters") {
         comment: none-3
     )YAML";
 
-
-    eckit::YAMLConfiguration data_cfg(data_conf_str);
-
     // configure
     EXPECT_EQUAL(plume::Manager::isConfigured(), false);
-
-    // valid configuration
-    plume::Manager::configure(mgr_cfg_valid_json);
-
-    // should be validly initialised
+    plume::Manager::configure(eckit::YAMLConfiguration(mgr_conf_str));
     EXPECT_EQUAL(plume::Manager::isConfigured(), true);
 
-
-    // negotiate
-    plume::Manager::negotiate(data_cfg);
-
-    // still configured
+    plume::Manager::negotiate(eckit::YAMLConfiguration(data_conf_str));
     EXPECT_EQUAL(plume::Manager::isConfigured(), true);
 
-    // expected to be active parame: I, J, XYZ, K
+    // expected active params: I, J, XYZ, K
     EXPECT_EQUAL(plume::Manager::getActiveParams().size(), 4);
 }
 
+
 CASE("test_derived_parameter") {
+
     std::string mgr_conf_str = R"YAML(
     plugins:
     - lib: simple_plugins
@@ -160,52 +254,17 @@ CASE("test_derived_parameter") {
             height: 100
     )YAML";
 
-    eckit::YAMLConfiguration mgr_cfg_derived_param(mgr_conf_str);
-
-    std::string data_conf_str = R"YAML(
-    offered:
-      - name: u
-        type: ATLAS_FIELD
-        available: always
-        comment: wind
-      - name: z
-        type: ATLAS_FIELD
-        available: always
-        comment: geopotential
-      - name: I
-        type: INT
-        available: always
-        comment: none-1
-      - name: J
-        type: INT
-        available: always
-        comment: none-1
-      - name: K
-        type: INT
-        available: always
-        comment: none-3
-    )YAML";
-
-    eckit::YAMLConfiguration data_cfg(data_conf_str);
-
-    // valid configuration
-    ManagerTestAccess::reset();
-    EXPECT_NOT(plume::Manager::isConfigured());
-    EXPECT_NO_THROW(plume::Manager::configure(mgr_cfg_derived_param));
-
-    // negotiate
-    EXPECT_NO_THROW(plume::Manager::negotiate(data_cfg));
+    resetConfigureNegotiate(mgr_conf_str, kOffersIJKUZ);
 
     std::set<std::string> expected = {"I", "J", "K", "u", "u;hl;100", "z"};
     std::set<std::string> activeParams(plume::Manager::getActiveParams().begin(),
                                        plume::Manager::getActiveParams().end());
-
-    // expected to be active params: u, z, u;hl;100
-    // not only the derived should be activated but also the dependencies
     EXPECT_EQUAL(activeParams, expected);
 }
 
+
 CASE("test_invalid_derived_parameter") {
+
     std::string mgr_conf_str = R"YAML(
     plugins:
     - lib: simple_plugins
@@ -217,40 +276,16 @@ CASE("test_invalid_derived_parameter") {
             invalid_option: 100
     )YAML";
 
-    eckit::YAMLConfiguration mgr_cfg_derived_param(mgr_conf_str);
-
-    std::string data_conf_str = R"YAML(
-    offered:
-      - name: u
-        type: ATLAS_FIELD
-        available: always
-        comment: wind
-      - name: I
-        type: INT
-        available: always
-        comment: none-1
-      - name: J
-        type: INT
-        available: always
-        comment: none-1
-      - name: K
-        type: INT
-        available: always
-        comment: none-3
-    )YAML";
-
-    eckit::YAMLConfiguration data_cfg(data_conf_str);
-
-    // valid configuration
     ManagerTestAccess::reset();
     EXPECT_NOT(plume::Manager::isConfigured());
-    EXPECT_NO_THROW(plume::Manager::configure(mgr_cfg_derived_param));
-
-    // negotiation fails hard because of invalid option
-    EXPECT_THROWS(plume::Manager::negotiate(data_cfg));
+    EXPECT_NO_THROW(plume::Manager::configure(eckit::YAMLConfiguration(mgr_conf_str)));
+    EXPECT_THROWS(plume::Manager::negotiate(eckit::YAMLConfiguration(kOffersIJKU)));
 }
 
+
 CASE("test_cannot_derive_parameter") {
+
+    // z is absent from the offers so u;hl;100 cannot be derived — plugin not activated.
     std::string mgr_conf_str = R"YAML(
     plugins:
     - lib: simple_plugins
@@ -262,46 +297,206 @@ CASE("test_cannot_derive_parameter") {
             height: 100
     )YAML";
 
-    eckit::YAMLConfiguration mgr_cfg_derived_param(mgr_conf_str);
+    resetConfigureNegotiate(mgr_conf_str, kOffersIJKU);
 
-    std::string data_conf_str = R"YAML(
-    offered:
-      - name: u
-        type: ATLAS_FIELD
-        available: always
-        comment: wind
-      - name: I
-        type: INT
-        available: always
-        comment: none-1
-      - name: J
-        type: INT
-        available: always
-        comment: none-1
-      - name: K
-        type: INT
-        available: always
-        comment: none-3
-    )YAML";
-
-    eckit::YAMLConfiguration data_cfg(data_conf_str);
-
-    // valid configuration
-    ManagerTestAccess::reset();
-    EXPECT_NOT(plume::Manager::isConfigured());
-    EXPECT_NO_THROW(plume::Manager::configure(mgr_cfg_derived_param));
-
-    // negotiate
-    EXPECT_NO_THROW(plume::Manager::negotiate(data_cfg));
-
-    // plugin did not load because the derived parameter could not be satisfied, so no active params
     std::set<std::string> expected = {};
     std::set<std::string> activeParams(plume::Manager::getActiveParams().begin(),
                                        plume::Manager::getActiveParams().end());
     EXPECT_EQUAL(activeParams, expected);
 }
 
-//----------------------------------------------------------------------------------------------------------------------
+
+CASE("test_writable_param_satisfied_via_config") {
+
+    // Model offers W_INT as writable; plugin config requires it as writable.
+    // write-back-policy: single-writer enables write-back.
+    // Expected: group accepted, W_INT in active params.
+
+    std::string mgr_conf_str = R"YAML(
+    write-back-policy: single-writer
+    plugins:
+    - lib: simple_plugins
+      name: SimplePlugin
+      parameters:
+        -
+          - name: W_INT
+            type: INT
+            writable: true
+      core-config: {}
+    )YAML";
+
+    resetConfigureNegotiate(mgr_conf_str, kOffersIJKWritableInt);
+    EXPECT_EQUAL(plume::Manager::getActiveParams().count("W_INT"), 1);
+}
+
+
+CASE("test_writable_param_rejected_via_config") {
+
+    // Model offers W_RO as read-only; plugin config requires it as writable.
+    // Rejection is because the offer is read-only, not the policy.
+    // Expected: group rejected, W_RO not in active params.
+
+    std::string mgr_conf_str = R"YAML(
+    write-back-policy: single-writer
+    plugins:
+    - lib: simple_plugins
+      name: SimplePlugin
+      parameters:
+        -
+          - name: W_RO
+            type: INT
+            writable: true
+      core-config: {}
+    )YAML";
+
+    resetConfigureNegotiate(mgr_conf_str, kOffersIJKReadonlyInt);
+    EXPECT_EQUAL(plume::Manager::getActiveParams().count("W_RO"), 0);
+}
+
+
+CASE("test_writable_offered_readonly_required_via_config") {
+
+    // Model offers W_INT as writable; plugin config requires it with no writable key (read-only).
+    // No write-back-policy needed: the plugin is not requesting write access.
+    // Expected: group accepted — a writable offer does not force plugins to request write access.
+
+    std::string mgr_conf_str = R"YAML(
+    plugins:
+    - lib: simple_plugins
+      name: SimplePlugin
+      parameters:
+        -
+          - name: W_INT
+            type: INT
+      core-config: {}
+    )YAML";
+
+    resetConfigureNegotiate(mgr_conf_str, kOffersIJKWritableInt);
+    EXPECT_EQUAL(plume::Manager::getActiveParams().count("W_INT"), 1);
+}
+
+
+CASE("test_write_back_policy_disabled_default") {
+
+    // No write-back-policy key in manager config -> disabled by default.
+    // Plugin requests W_INT as writable; expected: group rejected, plugin not activated.
+
+    std::string mgr_conf_str = R"YAML(
+    plugins:
+    - lib: simple_plugins
+      name: SimplePlugin
+      parameters:
+        -
+          - name: W_INT
+            type: INT
+            writable: true
+      core-config: {}
+    )YAML";
+
+    resetConfigureNegotiate(mgr_conf_str, kOffersIJKWritableInt);
+    EXPECT_EQUAL(plume::Manager::getActivePluginNames().size(), 0u);
+    EXPECT_EQUAL(plume::Manager::getActiveParams().count("W_INT"), 0);
+}
+
+
+CASE("test_write_back_policy_single_writer") {
+
+    // write-back-policy: single-writer — two plugins both request W_INT as writable.
+    // Expected: first plugin (SimplePlugin) accepted, second (SimpleDerivedPlugin) rejected.
+
+    resetConfigureNegotiate(mgrBothWriteWInt("single-writer"), kOffersIJKUZWritableInt);
+
+    auto activePluginNames = plume::Manager::getActivePluginNames();
+    EXPECT_EQUAL(activePluginNames.size(), 1u);
+    EXPECT_EQUAL(activePluginNames[0], std::string("SimplePlugin"));
+    EXPECT_EQUAL(plume::Manager::getActiveParams().count("W_INT"), 1);
+}
+
+
+CASE("test_write_back_policy_invalid_string") {
+
+    // An unrecognised policy string must be caught at configure() time.
+    std::string mgr_conf_str = R"YAML(
+    write-back-policy: unknown-policy
+    plugins: []
+    )YAML";
+
+    ManagerTestAccess::reset();
+    EXPECT_THROWS(plume::Manager::configure(eckit::YAMLConfiguration(mgr_conf_str)));
+}
+
+
+CASE("test_writable_conflict_multiple_plugins_both_accepted") {
+
+    // write-back-policy: multi-writer — both plugins request W_INT as writable.
+    // Expected: both accepted; run order matches config order.
+
+    resetConfigureNegotiate(mgrBothWriteWInt("multi-writer"), kOffersIJKUZWritableInt);
+
+    auto activePluginNames = plume::Manager::getActivePluginNames();
+    EXPECT_EQUAL(activePluginNames.size(), 2u);
+    EXPECT_EQUAL(activePluginNames[0], std::string("SimplePlugin"));
+    EXPECT_EQUAL(activePluginNames[1], std::string("SimpleDerivedPlugin"));
+}
+
+
+CASE("test_write_read_same_param_non_strict_allowed") {
+
+    // Writer (SimplePlugin, W_INT writable) + reader (SimpleDerivedPlugin, W_INT read-only).
+    // Policy: single-writer (non-strict) — both accepted, run order logged as warning.
+
+    resetConfigureNegotiate(mgrWriteReadWInt("single-writer"), kOffersIJKUZWritableInt);
+
+    auto activePluginNames = plume::Manager::getActivePluginNames();
+    EXPECT_EQUAL(activePluginNames.size(), 2u);
+    EXPECT_EQUAL(activePluginNames[0], std::string("SimplePlugin"));
+    EXPECT_EQUAL(activePluginNames[1], std::string("SimpleDerivedPlugin"));
+}
+
+
+CASE("test_write_read_same_param_strict_reader_rejected") {
+
+    // Writer (SimplePlugin, W_INT writable) + reader (SimpleDerivedPlugin, W_INT read-only).
+    // Policy: single-writer-strict — reader is rejected because a writer holds the param.
+
+    resetConfigureNegotiate(mgrWriteReadWInt("single-writer-strict"), kOffersIJKUZWritableInt);
+
+    auto activePluginNames = plume::Manager::getActivePluginNames();
+    EXPECT_EQUAL(activePluginNames.size(), 1u);
+    EXPECT_EQUAL(activePluginNames[0], std::string("SimplePlugin"));
+}
+
+
+CASE("test_write_derived_read_non_strict_allowed") {
+
+    // Writer (SimplePlugin, u:ATLAS_FIELD writable) +
+    // Derived-reader (SimpleDerivedPlugin, u;hl;100 derived from u).
+    // Policy: single-writer (non-strict) — both accepted, run order logged.
+
+    resetConfigureNegotiate(mgrWriteUDerived("single-writer"), kOffersIJKWritableAtlas);
+
+    auto activePluginNames = plume::Manager::getActivePluginNames();
+    EXPECT_EQUAL(activePluginNames.size(), 2u);
+    EXPECT_EQUAL(activePluginNames[0], std::string("SimplePlugin"));
+    EXPECT_EQUAL(activePluginNames[1], std::string("SimpleDerivedPlugin"));
+}
+
+
+CASE("test_write_derived_read_strict_derived_reader_rejected") {
+
+    // Writer (SimplePlugin, u:ATLAS_FIELD writable) +
+    // Derived-reader (SimpleDerivedPlugin, u;hl;100 derived from u).
+    // Policy: single-writer-strict — derived reader rejected because a writer holds the source.
+
+    resetConfigureNegotiate(mgrWriteUDerived("single-writer-strict"), kOffersIJKWritableAtlas);
+
+    auto activePluginNames = plume::Manager::getActivePluginNames();
+    EXPECT_EQUAL(activePluginNames.size(), 1u);
+    EXPECT_EQUAL(activePluginNames[0], std::string("SimplePlugin"));
+}
+
+
+//--------------------------------------------------------------------------------------------------
 
 }  // namespace plume::test
 

--- a/tests/core/test_protocol.cc
+++ b/tests/core/test_protocol.cc
@@ -103,6 +103,31 @@ CASE("test protocol - offered params") {
 }
 
 
+
+CASE("test protocol - writable offered params") {
+
+    plume::Protocol protocol;
+    protocol.offer<int>("W1", "always", "writable param", /*writable=*/true);
+    protocol.offer<int>("W2", "always", "read-only param");
+
+    EXPECT_EQUAL(protocol.offeredParamNames().size(), 2);
+    EXPECT_EQUAL(protocol.offers().getParam("W1").writable(), true);
+    EXPECT_EQUAL(protocol.offers().getParam("W2").writable(), false);
+}
+
+
+CASE("test protocol - writable required params") {
+
+    plume::Protocol protocol;
+    protocol.require<int>("R1");
+    protocol.requireWritable<int>("R2");
+
+    EXPECT_EQUAL(protocol.requiredParamNames().size(), 2);
+    EXPECT_EQUAL(protocol.requires().getParam("R1").writable(), false);
+    EXPECT_EQUAL(protocol.requires().getParam("R2").writable(), true);
+}
+
+
 //----------------------------------------------------------------------------------------------------------------------
 
 }  // namespace plume::test


### PR DESCRIPTION
### Description

I decided to break down the PRs for the two-way coupling feature as to allow more efficient and targeted review.
This PR implements the negotiation changes required in Plume. 

Other PRs will come: ifs-source plume module | Plume run phase (state pattern) | WF plugin 

The following criteria were applied:
- the model declares what parameters are writable (plume or model owned)
- the plugins request in read-only or writable mode either from the negotiate method or configuration
- the plume negotiator evaluates plugin needs and read/write intents: strict gating
- the write-back (coupling) feature handles cases where:
  - multiple plugins are loaded and consume the same parameters (readers and writers)
  - multiple plugins are loaded and write to the same parameter
  - a plugin writes to a parameter that is an actively observed observable
- Plume remains model agnostic
- models and plugins interface through the ModelData, no API breakage
- Plume monitors the coupling state [to come in the next PR] and ensures only plugins pre-authorised during negotiation do write back.

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/Contributor-License-Agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 
