### PR TITLE
PLUME-59: Remove atlas::FieldImpl support

### DIFF
--- a/src/plume/api/plume.cc
+++ b/src/plume/api/plume.cc
@@ -22,7 +22,6 @@
 
 #include "atlas/array.h"
 #include "atlas/field/Field.h"
-#include "atlas/field/detail/FieldImpl.h"
 
 #include "plume.h"
 #include "plume/Manager.h"
@@ -481,8 +480,11 @@ int plume_data_provide_double(plume_data_handle_t* h, const char* name, double* 
 // -------- Atlas objects
 int plume_data_provide_atlas_field_shared(plume_data_handle_t* h, const char* name, void* ptr) {
     return wrapApiFunction([h, name, ptr] {
-        auto field_ptr = static_cast<atlas::Field::Implementation*>(ptr);
-        h->impl_->provideParam(name, field_ptr);
+        // The Fortran/C boundary yields the model field's Implementation pointer; wrap it in an atlas::Field
+        // handle. provideParam copies this handle into the parameter (non-owning: the data stays model-owned),
+        // so this local wrapper may safely be destroyed on return.
+        atlas::Field field(static_cast<atlas::Field::Implementation*>(ptr));
+        h->impl_->provideParam(name, &field);
     });
 }
 

--- a/src/plume/data/FieldProvider.cc
+++ b/src/plume/data/FieldProvider.cc
@@ -11,6 +11,7 @@
 #include <sstream>
 
 #include "atlas/array.h"
+#include "atlas/util/Metadata.h"
 
 #include "plume/data/FieldProvider.h"
 #include "plume/data/ParameterValue.h"

--- a/src/plume/data/ModelData.h
+++ b/src/plume/data/ModelData.h
@@ -23,8 +23,9 @@
 #include "eckit/log/Log.h"
 #include "eckit/value/Value.h"
 
+#include "atlas/array/Array.h"
 #include "atlas/field/Field.h"
-#include "atlas/field/detail/FieldImpl.h"
+#include "atlas/util/Metadata.h"
 
 #include "plume/data/ParameterCatalogue.h"
 #include "plume/data/ParameterType.h"
@@ -83,13 +84,9 @@ public:
      *
      * @note Atlas fields can be created using this method from the C++ API, but there is no support for updating them
      *       directly at the moment. Use the `createParam` method with the subscription pattern instead.
-     * @todo The C API uses an Atlas internal type for field provision and access. Only the `Field` type should be used
-     *       by clients like Plume, so field implementation use should be removed.
      */
     template <typename T>
     void createParam(std::string name, T valInit) {
-        static_assert(!std::is_base_of_v<atlas::Field::Implementation, T>,
-                      "Atlas field implementations are only for observation");
         auto res = valueMap_.try_emplace(name, std::make_shared<ParameterValue<T, IParameterObserver>>(valInit));
         if (!res.second) {
             eckit::Log::warning() << "Parameter '" << name << "' already in Model Data. Not inserted!" << std::endl;
@@ -111,8 +108,6 @@ public:
      */
     template <typename T>
     void createParam(const std::string& strategy, const eckit::Configuration& config, std::string name = "") {
-        static_assert(!std::is_base_of_v<atlas::Field::Implementation, T>,
-                      "Atlas field implementations are only for observation");
         // 1. name the param entry using defaults or user instructions
         std::string paramName = name;
         if (paramName.empty()) {
@@ -148,9 +143,6 @@ public:
      */
     template <typename T>
     void provideParam(std::string name, T* ptr) {
-        if constexpr (std::is_same_v<T, atlas::Field> || std::is_same_v<T, atlas::Field::Implementation>) {
-            ASSERT_MSG(ptr->bytes() >= 0, "Provided Atlas field not readable!");
-        }
         auto res = valueMap_.try_emplace(name, std::make_shared<ParameterValue<T, IParameterObservable>>(ptr));
         if (!res.second) {
             eckit::Log::warning() << "Parameter '" << name << "' already in Model Data. Not inserted!" << std::endl;
@@ -158,9 +150,14 @@ public:
     }
 
     /**
-     * @brief Update the value of a created parameter, i.e., of an owned parameter that is not an Atlas field.
+     * @brief Update the value of a Plume-owned parameter.
      *
-     * @note Method not implemented for Atlas fields, which can only be updated through the observation pattern for now.
+     * Model-facing entry point for mutating data that Plume owns (created via createParam). This is distinct
+     * from the plugin-facing writeParam API. Parameters that are actively observing a source are updated by
+     * their update strategy and cannot be set directly here.
+     *
+     * @note For Atlas fields, only Plume-owned fields can be updated. Model-provided fields (provideParam) are
+     *       not owned by Plume and cannot be mutated through this method.
      */
     template <typename T>
     void updateParam(std::string name, T newVal) {
@@ -174,7 +171,21 @@ public:
             }
         }
         if (auto typedPtr = std::dynamic_pointer_cast<ParameterValueTyped<T>>(valueMap_.at(name))) {
-            typedPtr->set(newVal);
+            if (!typedPtr->owns()) {
+                throw eckit::UserError("Parameter '" + name + "' is not owned by Plume and cannot be updated!", Here());
+            }
+            if constexpr (std::is_same_v<T, atlas::Field>) {
+                atlas::Field& owned = typedPtr->getSettableField();
+                if (owned.shape() != newVal.shape() || owned.datatype() != newVal.datatype()) {
+                    throw eckit::UserError(
+                        "Cannot update Atlas field '" + name + "': shape or datatype mismatch with the source field.",
+                        Here());
+                }
+                owned.array().copy(newVal.array());
+            }
+            else {
+                typedPtr->set(newVal);
+            }
         }
         else {
             throw eckit::BadCast("Plume parameter update type mismatch!", Here());
@@ -186,19 +197,13 @@ public:
      *
      * @note This interface can be used for source & derived params if the full name is known.
      */
-    template <typename T, typename = std::enable_if_t<!std::is_same<T, atlas::Field::Implementation>::value>>
+    template <typename T>
     T getParam(std::string name) const {
         if (!hasParameter(name)) {
             throw eckit::BadParameter("Parameter '" + name + "' not found in model data!", Here());
         }
         if (auto typedPtr = std::dynamic_pointer_cast<ParameterValueTyped<T>>(valueMap_.at(name))) {
             return typedPtr->get();
-        }
-        if constexpr (std::is_same_v<T, atlas::Field>) {
-            if (auto typedPtr =
-                    std::dynamic_pointer_cast<ParameterValueTyped<atlas::Field::Implementation>>(valueMap_.at(name))) {
-                return atlas::Field(&(typedPtr->get()));
-            }
         }
         throw eckit::BadCast("Plume parameter view update type mismatch!", Here());
     }

--- a/src/plume/data/ParameterType.h
+++ b/src/plume/data/ParameterType.h
@@ -17,7 +17,6 @@
 #include "eckit/exception/Exceptions.h"
 
 #include "atlas/field/Field.h"
-#include "atlas/field/detail/FieldImpl.h"
 
 namespace plume {
 namespace data {
@@ -92,10 +91,6 @@ struct DeduceParameterType<atlas::Field> {
     static constexpr ParameterType value = ParameterType::ATLAS_FIELD;
     static constexpr const char* name    = "ATLAS_FIELD";
 };
-
-/** @warning To remove once Plume API does not use field implementations. */
-template <>
-struct DeduceParameterType<atlas::Field::Implementation> : DeduceParameterType<atlas::Field> {};
 
 /**
  * @brief Deduce the ParameterType associated with the given template type parameter.

--- a/src/plume/data/ParameterValue.h
+++ b/src/plume/data/ParameterValue.h
@@ -19,7 +19,6 @@
 #include "eckit/exception/Exceptions.h"
 
 #include "atlas/field/Field.h"
-#include "atlas/field/detail/FieldImpl.h"
 
 #include "plume/data/FieldProvider.h"
 #include "plume/data/ParameterType.h"
@@ -63,7 +62,7 @@ private:
     bool ownsValue_;
     ParameterType type_;
 
-    std::optional<T> ownedValue_;  ///< Only used when the object owns its value.
+    std::optional<T> ownedValue_;  ///< Backing storage for an owned value, or a shared handle held for lifetime.
     T* valuePtr_;                  ///< Non-owning pointer; the pointee must outlive this object if it is not owned.
 
 public:
@@ -73,22 +72,31 @@ public:
      * @brief Constructs an owning parameter with a copied value.
      *
      * Transfers ownership of the passed `value` to the object.
-     *
-     * @warning While Atlas fields can be owned, it is not the case for field implementations which are currently
-     *          used by the C API. Support for field implementations should be removed in the future, in the meantime,
-     *          this constructor is disabled for `T == atlas::Field::Implementation`.
      */
-    template <typename U = T, typename = std::enable_if_t<!std::is_same<U, atlas::Field::Implementation>::value>>
     ParameterValueTyped(T value) :
         ownsValue_(true), ownedValue_(std::move(value)), valuePtr_(&ownedValue_.value()), type_(deduceType<T>()) {}
 
     /**
-     * @brief Constructs a non-owning parameter from a raw pointer.
+     * @brief Constructs a non-owning parameter from a pointer to data owned elsewhere (typically the model).
+     *
+     * For most types the pointer is stored directly, so the pointee must outlive this object. Atlas fields are the
+     * exception: `atlas::Field` is a reference-counted handle around model-owned data, so a copy of the handle is
+     * kept as backing storage to keep the field accessible for the session. In both cases the parameter stays
+     * non-owning (`ownsValue_ == false`): Plume does not own the underlying data, so `set()`/`getSettableField()`
+     * remain disallowed and `updateParam` cannot mutate it.
      *
      * @question: do we need special cases for char, char* ? There is currently no support in the C API.
      */
-    ParameterValueTyped(T* ptr) : ownsValue_(false), valuePtr_(ptr), type_(deduceType<T>()) {
+    ParameterValueTyped(T* ptr) : ownsValue_(false), type_(deduceType<T>()) {
         ASSERT_MSG(ptr != nullptr, "Non-owning ParameterValue constructed with null pointer");
+        if constexpr (std::is_same_v<T, atlas::Field>) {
+            ASSERT_MSG(ptr->bytes() >= 0, "Provided Atlas field not readable!");
+            ownedValue_ = *ptr;  // copy the handle to keep model-owned data alive; ownsValue_ stays false
+            valuePtr_   = &ownedValue_.value();
+        }
+        else {
+            valuePtr_ = ptr;
+        }
     }
 
     /// Deleted copy constructor & copy assignment operator.
@@ -110,6 +118,9 @@ public:
 
     /**
      * @brief Sets the parameter value.
+     *
+     * For Atlas fields this replaces the stored handle, which lets update strategies reshape or reinitialise an
+     * owned field. Model-facing in-place mutation that preserves the handle identity is done via updateParam.
      *
      * @pre This instance must own its value.
      */

--- a/tests/api/CMakeLists.txt
+++ b/tests/api/CMakeLists.txt
@@ -86,3 +86,9 @@ add_fctest( TARGET   plume_test_params_fapi
             LIBS
               plume_f
 )
+
+add_fctest( TARGET   plume_test_atlas_field_lifetime_fapi
+            SOURCES  test_atlas_field_lifetime.F90
+            LIBS
+              plume_f
+)

--- a/tests/api/test_atlas_field_lifetime.F90
+++ b/tests/api/test_atlas_field_lifetime.F90
@@ -1,0 +1,73 @@
+! (C) Copyright 2025- ECMWF.
+!
+! This software is licensed under the terms of the Apache Licence Version 2.0
+! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+!
+! In applying this licence, ECMWF does not waive the privileges and immunities
+! granted to it by virtue of its status as an intergovernmental organisation nor
+! does it submit to any jurisdiction.
+
+#include "fckit/fctest.h"
+
+
+TESTSUITE( test_atlas_field_lifetime_suite )
+
+! Crosses the Fortran/C API to guard against the write-back refactor storing a
+! dangling pointer when an atlas::Field is provided. The C side wraps the model's
+! Field::Implementation* in a *local* atlas::Field before storing it; if Plume keeps
+! a raw pointer to that local, it dangles as soon as the provide call returns.
+! We therefore provide a field with known data, run intervening C-API calls to reuse
+! the C stack, then read the field back and check its DATA (not just its name).
+TEST( test_atlas_field_lifetime )
+use atlas_module
+use plume_module
+use fckit_module
+implicit none
+
+type(plume_data) :: data
+type(atlas_Field) :: field
+type(atlas_Field) :: field_check
+integer(c_int), pointer :: fdata(:)
+integer(c_int), pointer :: fdata_check(:)
+
+! scalar params used to exercise the C stack between provide and get
+integer :: scratch = 123
+integer :: scratch_check = -999
+
+call atlas_library%initialise()
+call plume_check(plume_initialise())
+call plume_check(data%initialise())
+
+! provided field carrying known data
+field = atlas_Field("LF", atlas_integer(), (/4/))
+call field%data(fdata)
+fdata(1) = 11
+fdata(2) = 22
+fdata(3) = 33
+fdata(4) = 44
+
+call plume_check(data%provide_atlas_field_shared("LF", field))
+
+! intervening C-API calls: push/pop frames over the region where the C-side
+! temporary atlas::Field wrapper lived, so a dangling read is not masked.
+call plume_check(data%provide_int("SCRATCH", scratch))
+call plume_check(data%get_int("SCRATCH", scratch_check))
+FCTEST_CHECK(scratch_check == 123)
+
+! read the provided field back and validate its data survived
+call plume_check(data%get_shared_atlas_field("LF", field_check))
+FCTEST_CHECK(field_check%name() == "LF")
+
+call field_check%data(fdata_check)
+FCTEST_CHECK(fdata_check(1) == 11)
+FCTEST_CHECK(fdata_check(2) == 22)
+FCTEST_CHECK(fdata_check(3) == 33)
+FCTEST_CHECK(fdata_check(4) == 44)
+
+call plume_check(data%finalise())
+call plume_check(plume_finalise())
+call atlas_library%finalise()
+
+END_TEST
+
+END_TESTSUITE

--- a/tests/core/test_atlas_model_data.cc
+++ b/tests/core/test_atlas_model_data.cc
@@ -9,6 +9,7 @@
  * does it submit to any jurisdiction.
  */
 #include <string>
+#include <vector>
 
 #include "eckit/config/LocalConfiguration.h"
 #include "eckit/testing/Test.h"
@@ -16,7 +17,9 @@
 #include "plume/data/ModelData.h"
 
 #include "atlas/array/ArrayShape.h"
+#include "atlas/array/ArrayView.h"
 #include "atlas/array/DataType.h"
+#include "atlas/array/MakeView.h"
 #include "atlas/field/Field.h"
 
 
@@ -75,21 +78,30 @@ struct UpdateStrategyTraits<DummyAtlasStrategy> {
 namespace plume::test {
 
 // separating these tests so they can be toggled off if atlas is disabled
-CASE("test model data - atlas fields checks") {
+
+CASE("test model data - atlas fields creation and provision") {
 
     plume::data::ModelData data;
 
     atlas::Field paramField("dummy", atlas::array::make_datatype<int>(), atlas::array::make_shape(1, 2, 3));
     atlas::Field ownedParamField("ownedDummy", atlas::array::make_datatype<int>(), atlas::array::make_shape(1, 2, 3));
 
-    data.provideParam("param-field", &paramField);  /// checking field provision
+    // Provide a model-owned field, then confirm it is retrievable as an atlas::Field but not as another type.
+    data.provideParam("param-field", &paramField);
     EXPECT_THROWS(data.getParam<int>("param-field"));
     EXPECT_NO_THROW(data.getParam<atlas::Field>("param-field"));
 
-    /// checking field creation - although not directly usable for Atlas fields, see observation test for expected use
+    // Create a Plume-owned field. Direct creation is not the intended usage for Atlas fields (see the
+    // observation test for the expected subscription pattern); this only checks the resulting entry type.
     data.createParam("owned-param-field", std::move(ownedParamField));
     EXPECT_THROWS(data.getParam<int>("owned-param-field"));
     EXPECT_NO_THROW(data.getParam<atlas::Field>("owned-param-field"));
+
+    // updateParam mutates Plume-owned data only: it succeeds on the created field but is rejected on the
+    // model-provided field, which Plume does not own.
+    atlas::Field source("source", atlas::array::make_datatype<int>(), atlas::array::make_shape(1, 2, 3));
+    EXPECT_NO_THROW(data.updateParam<atlas::Field>("owned-param-field", source));
+    EXPECT_THROWS(data.updateParam<atlas::Field>("param-field", source));
 }
 
 CASE("test model data - observing atlas fields") {
@@ -110,27 +122,112 @@ CASE("test model data - observing atlas fields") {
 
     EXPECT(data.hasParameter("observable;dummy;00"));
 
-    auto oberserverView   = atlas::array::make_view<int, 1>(data.getParam<atlas::Field>("observable;dummy;00"));
-    auto oberservableView = atlas::array::make_view<int, 1>(data.getParam<atlas::Field>("observable"));
-    EXPECT_EQUAL(oberservableView.shape(0), 4);
-    EXPECT_EQUAL(oberservableView(0), 1);
-    EXPECT_EQUAL(oberserverView.shape(0), 4);
-    EXPECT_EQUAL(oberserverView(0), 1);  // cloned from source before first strategy run
-    EXPECT_EQUAL(oberservableView(3), 4);
-    EXPECT_EQUAL(oberserverView(3), 4);  // cloned from source before first strategy run
+    // Before any data change, the observer holds a clone of the source values.
+    auto observerView   = atlas::array::make_view<int, 1>(data.getParam<atlas::Field>("observable;dummy;00"));
+    auto observableView = atlas::array::make_view<int, 1>(data.getParam<atlas::Field>("observable"));
+    EXPECT_EQUAL(observableView.shape(0), 4);
+    EXPECT_EQUAL(observableView(0), 1);
+    EXPECT_EQUAL(observerView.shape(0), 4);
+    EXPECT_EQUAL(observerView(0), 1);
+    EXPECT_EQUAL(observableView(3), 4);
+    EXPECT_EQUAL(observerView(3), 4);
 
-    for (size_t i = 0; i < oberservableView.shape(0); ++i) {
-        oberservableView(i) = 10 * i;
+    // Mutate the source data and mark it updated to trigger the strategy on the observer.
+    for (size_t i = 0; i < observableView.shape(0); ++i) {
+        observableView(i) = 10 * i;
     }
     data.setUpdated({"observable"});
     EXPECT(data.isUpdated("observable;dummy;00"));
 
-    oberserverView   = atlas::array::make_view<int, 1>(data.getParam<atlas::Field>("observable;dummy;00"));
-    oberservableView = atlas::array::make_view<int, 1>(data.getParam<atlas::Field>("observable"));
-    EXPECT_EQUAL(oberservableView(0), 0);
-    EXPECT_EQUAL(oberserverView(0), 1);
-    EXPECT_EQUAL(oberservableView(3), 30);
-    EXPECT_EQUAL(oberserverView(3), 31);
+    // After the update, the observer reflects the new source values plus one (per DummyAtlasStrategy).
+    observerView   = atlas::array::make_view<int, 1>(data.getParam<atlas::Field>("observable;dummy;00"));
+    observableView = atlas::array::make_view<int, 1>(data.getParam<atlas::Field>("observable"));
+    EXPECT_EQUAL(observableView(0), 0);
+    EXPECT_EQUAL(observerView(0), 1);
+    EXPECT_EQUAL(observableView(3), 30);
+    EXPECT_EQUAL(observerView(3), 31);
+}
+
+/**
+ * @brief Ensures a provided Atlas field remains valid after the caller's handle is destroyed.
+ *
+ * Reproduces the C-API code path of `plume_data_provide_atlas_field_shared`, where a temporary local `atlas::Field`
+ * wrapper around the model's `Implementation` pointer is handed to `provideParam` and then destroyed on return.
+ * This case pins the contract: a field provided must remain valid (no use-after-free) and carry its original data.
+ */
+CASE("test model data - atlas::Field provided via a temporary wrapper must not dangle") {
+    plume::data::ModelData data;
+
+    // Model-owned storage that outlives Plume, simulating model-managed memory.
+    std::vector<int> values{11, 22, 33, 44};
+    atlas::Field modelField("modelField", values.data(), atlas::array::make_shape(values.size()));
+
+    // Mirror the C-API path: a local atlas::Field wrapping the model's Implementation pointer is provided
+    // by address, then destroyed at the end of this scope.
+    {
+        atlas::Field wrapper(modelField.get());
+        data.provideParam("provided", &wrapper);
+    }
+
+    // Poison the freed stack region so a dangling read cannot be masked by stale-but-intact stack bytes.
+    volatile char scratch[512];
+    for (int i = 0; i < 512; ++i) {
+        scratch[i] = static_cast<char>(i);
+    }
+
+    // The provided field and its data must still be intact.
+    atlas::Field got = data.getParam<atlas::Field>("provided");
+    auto view        = atlas::array::make_view<int, 1>(got);
+    EXPECT_EQUAL(view.shape(0), 4);
+    EXPECT_EQUAL(view(0), 11);
+    EXPECT_EQUAL(view(3), 44);
+}
+
+CASE("test model data - model-facing updateParam on Plume-owned atlas fields") {
+    plume::data::ModelData data;
+
+    // Create a Plume-owned field backed by its own atlas-allocated storage (independent of any external
+    // buffer) and seed it with initial values. The field handle is deliberately destroyed at the end of this
+    // scope: createParam takes the field by value and shares its reference-counted implementation, so the
+    // parameter must keep the data alive on its own without the caller retaining any handle.
+    {
+        atlas::Field ownedInit("owned", atlas::array::make_datatype<int>(), atlas::array::make_shape(4));
+        auto initView = atlas::array::make_view<int, 1>(ownedInit);
+        for (int i = 0; i < 4; ++i) {
+            initView(i) = i + 1;
+        }
+        data.createParam("owned", ownedInit);
+    }
+
+    // Capture the underlying implementation to assert the handle identity survives the update, and confirm
+    // the field starts out carrying the initial values.
+    atlas::Field before                            = data.getParam<atlas::Field>("owned");
+    auto beforeView                                = atlas::array::make_view<int, 1>(before);
+    const atlas::Field::Implementation* implBefore = before.get();
+    EXPECT_EQUAL(beforeView(0), 1);
+    EXPECT_EQUAL(beforeView(3), 4);
+
+    // Build a source field carrying the new values and update the owned field in place.
+    std::vector<int> updated{10, 20, 30, 40};
+    atlas::Field source("source", updated.data(), atlas::array::make_shape(updated.size()));
+    EXPECT_NO_THROW(data.updateParam<atlas::Field>("owned", source));
+
+    // The data must reflect the update while the handle continues to point at the same implementation.
+    atlas::Field after = data.getParam<atlas::Field>("owned");
+    EXPECT(after.get() == implBefore);
+    auto afterView = atlas::array::make_view<int, 1>(after);
+    EXPECT_EQUAL(afterView(0), 10);
+    EXPECT_EQUAL(afterView(3), 40);
+
+    // A field the model merely provides is not owned by Plume and cannot be updated.
+    std::vector<int> providedValues{5, 6, 7, 8};
+    atlas::Field providedField("provided", providedValues.data(), atlas::array::make_shape(providedValues.size()));
+    data.provideParam("provided", &providedField);
+    EXPECT_THROWS(data.updateParam<atlas::Field>("provided", source));
+
+    // A source field whose shape does not match the owned field is rejected.
+    atlas::Field wrongShape("wrong", atlas::array::make_datatype<int>(), atlas::array::make_shape(2));
+    EXPECT_THROWS(data.updateParam<atlas::Field>("owned", wrongShape));
 }
 
 }  // namespace plume::test

--- a/tests/core/test_update_strategies.cc
+++ b/tests/core/test_update_strategies.cc
@@ -11,6 +11,8 @@
 #include <array>
 #include <memory>
 
+#include "atlas/array/ArrayView.h"
+#include "atlas/array/MakeView.h"
 #include "atlas/field/Field.h"
 
 #include "eckit/testing/Test.h"
@@ -32,7 +34,7 @@ CASE("test update strategies - wind at height") {
     u.set_levels(5);
 
     // mimick how the model data creates the target field
-    atlas::Field u200tmp = u.clone();
+    atlas::Field u200tmp  = u.clone();
     atlas::Field u5000tmp = u.clone();
 
     EXPECT_EQUAL(u200tmp.levels(), 5);


### PR DESCRIPTION
### Description

Confined the use of `atlas::Field::Implementation` to C boundary crossing and removed support in Plume data module as this should be an internal atlas implementation detail.

To keep the current behaviour, Plume retains its own handle of the provided atlas fields owned by the model, while keeping the ownership boolean to false to prevent operations such as `updateParam` intended to mutate Plume-owned data.

This refactor allowed to unlock the expected behaviour for `updateParam` in the case of Plume-owned atlas fields which are not observers (no use case for this at the moment).

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/Contributor-License-Agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 
