### PR TITLE
PLUME-59 (on writeParam) & PLUME-75: write back structural model data guards

### DIFF
--- a/src/plume/CMakeLists.txt
+++ b/src/plume/CMakeLists.txt
@@ -29,6 +29,8 @@ set(PLUGIN_FILES_H
     PluginCore.h
     Configurable.h
     data/ModelData.h
+    data/ModelDataView.h
+    data/FieldAccess.h
     data/ParameterCatalogue.h
     data/ParameterType.h
     data/ParameterValue.h
@@ -52,6 +54,7 @@ set(PLUGIN_FILES_CC
     data/ParameterValue.cc
     data/DataChecker.cc
     data/FieldProvider.cc
+    data/FieldAccess.cc
     coupling/WriteBackPolicy.cc
     coupling/WriteAuthorisation.cc
     coupling/WriteBackLedger.cc
@@ -101,6 +104,9 @@ set(PLUME_PLUGIN_MANAGER_SOURCES
     coupling/WriteBackLedger.cc
     data/ModelData.h
     data/ModelData.cc
+    data/ModelDataView.h
+    data/FieldAccess.h
+    data/FieldAccess.cc
     data/ParameterType.h
     data/ParameterCatalogue.h
     data/ParameterCatalogue.cc

--- a/src/plume/Manager.cc
+++ b/src/plume/Manager.cc
@@ -213,8 +213,8 @@ void Manager::feedPlugins(data::ModelData& data) {
         }
 
         // get the share of run data needed to run the plugincore
-        auto requiredParams          = pluginHandler.getRequiredParamNames();
-        data::ModelData requiredData = data.filter(requiredParams, pluginHandler.pluginName());
+        auto requiredParams              = pluginHandler.getRequiredParamNames();
+        data::ModelDataView requiredData = data.filter(requiredParams, pluginHandler.pluginName());
 
         // grab data
         pluginHandler.grabData(requiredData);

--- a/src/plume/PluginCore.cc
+++ b/src/plume/PluginCore.cc
@@ -23,13 +23,21 @@ std::string PluginCore::name() const {
 }
 
 // grab the data that it needs
-void PluginCore::grabData(const data::ModelData& data) {
+void PluginCore::grabData(data::ModelDataView data) {
     modelData_ = data;
 };
 
 
-data::ModelData& PluginCore::modelData() {
-    return modelData_;
+data::ModelDataView& PluginCore::modelData() {
+    ASSERT(modelData_.has_value());
+    return *modelData_;
+}
+
+
+// Drop the plugin-facing view during finalise() (while atlas is alive), not at static program exit. See
+// PluginCore.h. (PLUME-82) needed only because views co-own model parameters; observer views would obviate it.
+void PluginCore::releaseData() {
+    modelData_.reset();
 }
 
 

--- a/src/plume/PluginCore.h
+++ b/src/plume/PluginCore.h
@@ -12,12 +12,13 @@
 
 #include <iostream>
 #include <map>
+#include <optional>
 #include <string>
 
 #include "eckit/config/Configuration.h"
 #include "eckit/exception/Exceptions.h"
 
-#include "plume/data/ModelData.h"
+#include "plume/data/ModelDataView.h"
 
 
 namespace plume {
@@ -61,10 +62,26 @@ public:
 
     /**
      * @brief Grab the necessary data that it needs from available data
-     * 
-     * @param data 
+     *
+     * @param data  the plugin-facing view produced by ModelData::filter()
      */
-    void grabData(const data::ModelData& data);
+    void grabData(data::ModelDataView data);
+
+    /**
+     * @brief Release the grabbed plugin-facing model data view at teardown.
+     *
+     * Called by PluginHandler::teardown(). The core is owned by the process-static PluginRegistry, so the
+     * grabbed view (which shares the model's atlas::Field handles) must be dropped here — during the model's
+     * finalise() while atlas is still alive — rather than at program exit when atlas' thread-local allocation
+     * machinery has already been destroyed (which corrupts the heap).
+     *
+     * @note (PLUME-82) This explicit release is a consequence of the current design in which a ModelDataView
+     *       *co-owns* the model's parameters (shared_ptr copies; see ModelData::filter and the ModelDataView
+     *       class note). If views became non-owning observers of model parameters, plugin-view teardown would
+     *       no longer destroy atlas::Field handles and this method would be unnecessary. PLUME-82 tracks that
+     *       refactor.
+     */
+    void releaseData();
 
     /**
      * @brief Setup
@@ -90,11 +107,17 @@ public:
 
 protected:
 
-    data::ModelData& modelData();
+    data::ModelDataView& modelData();
 
 private:
 
-    data::ModelData modelData_;
+    /** @brief Plugin-facing model data view.
+     * 
+     * Optional because ModelDataView has no default constructor — it only exists once filtered from real ModelData.
+     * PluginCore is constructed before grabData() supplies the view, so the member starts empty and modelData() asserts
+     * it is engaged, turning premature access into a clear error.
+     */
+    std::optional<data::ModelDataView> modelData_;
 };
 
 

--- a/src/plume/PluginHandler.cc
+++ b/src/plume/PluginHandler.cc
@@ -40,7 +40,7 @@ const std::set<plume::data::ParameterDefinition>& PluginHandler::getRequiredPara
 }
 
 
-void PluginHandler::grabData(const data::ModelData& data) {
+void PluginHandler::grabData(data::ModelDataView data) {
     plugincorePtr_->grabData(data);
 }
 
@@ -57,6 +57,11 @@ void PluginHandler::run() {
 
 void PluginHandler::teardown() {
     plugincorePtr_->teardown();
+    // Drop the grabbed model data view now — during the model's finalise() while atlas is still alive —
+    // rather than at program exit (see PluginCore::releaseData()). The empty PluginCore itself lingers in
+    // the process-static PluginRegistry (only the test-only Manager::reset() erases it), but once its data
+    // view is released it holds no atlas::Field, so that lingering is harmless.
+    plugincorePtr_->releaseData();
 }
 
 std::string PluginHandler::pluginName() const {

--- a/src/plume/PluginHandler.h
+++ b/src/plume/PluginHandler.h
@@ -74,7 +74,7 @@ public:
      * 
      * @param data 
      */
-    void grabData(const data::ModelData& data);
+    void grabData(data::ModelDataView data);
 
     /**
      * @brief setup the plugincore

--- a/src/plume/api/plume.F90
+++ b/src/plume/api/plume.F90
@@ -11,7 +11,7 @@ module plume_module
 use plume_lib_module, only : plume_initialise, &
                              plume_finalise
 
-use plume_data_module, only : plume_data
+use plume_data_module, only : plume_data, plume_data_view
 use plume_manager_module, only : plume_manager
 use plume_protocol_module, only : plume_protocol
 use plume_utils_module, only : fortranise_cstr
@@ -33,6 +33,7 @@ public :: plume_initialise
 public :: plume_finalise
 
 public :: plume_data
+public :: plume_data_view
 public :: plume_manager
 public :: plume_protocol
 

--- a/src/plume/api/plume.cc
+++ b/src/plume/api/plume.cc
@@ -11,6 +11,7 @@
 #include <functional>
 #include <iostream>
 #include <map>
+#include <memory>
 #include <vector>
 
 #include "eckit/config/YAMLConfiguration.h"
@@ -321,6 +322,9 @@ int plume_manager_active_fields(plume_manager_handle_t* h, char** str_in) {
     return wrapApiFunction([h, &str_in] {
         ASSERT(h);
         ASSERT((h)->impl_);
+        ASSERT(str_in);
+        // Clear output up front so a failure never leaves a stale pointer with the caller.
+        *str_in = nullptr;
 
         // Decide how we want to wrap the data..
         auto req_params = h->impl_->getActiveParams();
@@ -343,7 +347,10 @@ int plume_manager_active_data_catalogue(plume_manager_handle_t* h, void** active
     return wrapApiFunction([h, &active_data_catalogue] {
         ASSERT(h);
         ASSERT((h)->impl_);
- 
+        ASSERT(active_data_catalogue);
+        // Clear output up front so a failure never leaves a stale pointer with the caller.
+        *active_data_catalogue = nullptr;
+
         *active_data_catalogue = new eckit::LocalConfiguration(h->impl_->getActiveDataCatalogue().getConfig());
     });
 }
@@ -531,8 +538,20 @@ int plume_data_provide_atlas_field_shared(plume_data_handle_t* h, const char* na
 
 
 // ----------------- Data view "updaters" (Plugin API) -----------------
+//
+// NOTE (PLUME-75): the read-only field guarantee is C++-ONLY. On the C++ side, a plugin holding a
+// data::ModelDataView gets getParam<atlas::Field> back as a read-only data::FieldView (no mutable handle escapes).
+// This C entry point, however, wraps a full data::ModelData* and hands the raw FieldImpl pointer straight to the
+// Fortran atlas_field below, so a Fortran plugin still receives a fully mutable field that shares the model's buffer
+// and can bypass the write-back ledger. Extending the FieldView-style enforcement to the Fortran/C path is a
+// possible follow-up (needs a read-only Fortran field wrapper or a copy-returning entry point).
 int plume_data_get_shared_atlas_field(plume_data_handle_t* h, const char* name, void** ptr) {
-    return wrapApiFunction([h, name, ptr] { *ptr = h->impl_->getParam<atlas::Field>(name).get(); });
+    return wrapApiFunction([h, name, ptr] {
+        ASSERT(ptr);
+        // Clear output up front so a failure never leaves a stale pointer with the caller.
+        *ptr = nullptr;
+        *ptr = h->impl_->getParam<atlas::Field>(name).get();
+    });
 }
 
 int plume_data_get_int(plume_data_handle_t* h, const char* name, int* val) {
@@ -607,10 +626,40 @@ int plume_data_write_atlas_field(plume_data_handle_t* h, const char* name, void*
     });
 }
 
+// C-side backing for the Fortran plume_write_scope. Buffer fetched as in plume_data_get_shared_atlas_field:
+// h->impl_ is statically a ModelData* and getParam is non-virtual, so it binds to the mutable ModelData::getParam.
+int plume_data_write_scope_begin(plume_data_handle_t* h, const char* name, void** scope_out, void** field_ptr_out) {
+    return wrapApiFunction([h, name, scope_out, field_ptr_out] {
+        ASSERT(h);
+        ASSERT(h->impl_);
+        ASSERT(scope_out);
+        ASSERT(field_ptr_out);
+        // Clear outputs up front so a failed staging never leaves stale pointers with the caller.
+        *scope_out     = nullptr;
+        *field_ptr_out = nullptr;
+        // Stage first: throws cleanly (nothing allocated) if unauthorised/policy-violating.
+        auto scope     = std::make_unique<plume::data::WriteScope>(h->impl_->writeParam(name));
+        *field_ptr_out = h->impl_->getParam<atlas::Field>(name).get();
+        *scope_out     = scope.release();
+    });
+}
+
+int plume_data_write_scope_commit(void* scope) {
+    return wrapApiFunction([scope] {
+        ASSERT(scope);
+        // Adopt ownership so the WriteScope is always freed, even if commit() throws.
+        std::unique_ptr<plume::data::WriteScope> s(static_cast<plume::data::WriteScope*>(scope));
+        s->commit();
+    });
+}
+
 int plume_data_pending_writebacks(plume_data_handle_t* h, char** names) {
     return wrapApiFunction([h, &names] {
         ASSERT(h);
         ASSERT(h->impl_);
+        ASSERT(names);
+        // Clear output up front so a failure never leaves a stale pointer with the caller.
+        *names = nullptr;
         auto pending = h->impl_->pendingWritebacks();
         std::string tmp;
         for (const auto& p : pending) {

--- a/src/plume/api/plume.h
+++ b/src/plume/api/plume.h
@@ -519,6 +519,38 @@ int plume_data_write_double(plume_data_handle_t* h, const char* name, double val
 int plume_data_write_atlas_field(plume_data_handle_t* h, const char* name, void* ptr);
 
 /**
+ * @brief Begin an in-place write-back scope for an Atlas field (plugin-side API).
+ *
+ * Stages the write with the authorisation ledger (fails if the plugin is not authorised or the single-writer
+ * policy is violated) and returns an opaque scope handle plus the staged field's Implementation pointer. The
+ * returned pointer aliases the model's own buffer, so the caller can mutate it in place (no copy) and then finalise
+ * with plume_data_write_scope_commit. This is the copy-free counterpart of plume_data_write_atlas_field.
+ *
+ * @note This (and plume_data_write_atlas_field) is the authorised write-back path: staging runs the ledger's
+ *       authorisation/policy check, signals the model, and records an audit of writing plugins. Mutating a field
+ *       obtained from plume_data_get_shared_atlas_field bypasses all of that (unauthorised, unsignalled, untraced).
+ *       On the C/Fortran boundary this is convention-enforced only, not structural.
+ *
+ * @param h Handle (filtered plugin view — consumer identity carried internally)
+ * @param name Parameter name
+ * @param scope_out Output: opaque write-scope handle (finalise with plume_data_write_scope_commit)
+ * @param field_ptr_out Output: pointer to the staged atlas::Field::Implementation (the model's own buffer)
+ * @return Error code
+ */
+int plume_data_write_scope_begin(plume_data_handle_t* h, const char* name, void** scope_out, void** field_ptr_out);
+
+/**
+ * @brief Commit and free an in-place write-back scope opened with plume_data_write_scope_begin (plugin-side API).
+ *
+ * Finalises the scope (leaving the ledger slot staged for the model flush) and frees the scope handle. The handle
+ * must not be used afterwards. Always frees the scope, even if committing reports an error.
+ *
+ * @param scope Opaque write-scope handle returned by plume_data_write_scope_begin
+ * @return Error code
+ */
+int plume_data_write_scope_commit(void* scope);
+
+/**
  * @brief Free a C string previously returned by a Plume API function (e.g. plume_data_pending_writebacks,
  * plume_manager_active_fields). Use this instead of delete[] directly — required for Fortran callers.
  *

--- a/src/plume/api/plume_data.F90
+++ b/src/plume/api/plume_data.F90
@@ -14,13 +14,47 @@ use plume_utils_module, only : fortranise_cstr
 
 use atlas_module
 
-! PLUME data ("C"-handle wrapper)
-type, public :: plume_data
+! PLUME data view — the plugin-facing handle. Binds ONLY plugin-legal procedures (read access +
+! write-back + the plugin bridge entry point initialise_from_ptr). The model-facing plume_data type
+! below EXTENDS this, adding the model-only mutators. Because Fortran type extension can only ADD
+! bindings, a plugin that holds a plume_data_view has no create_*/provide_*/update_*/set_updated/
+! pending_writebacks/acknowledge_writeback bindings at all: calling them is a compile-time error.
+!
+! NOTE — the inheritance is INVERTED relative to the C++ side, because the two languages restrict
+! differently. In C++, ModelDataView DERIVES from the full ModelData (private inheritance) and HIDES the
+! members it must not expose. In Fortran, extension can only add — never remove — so the restricted VIEW
+! must be the BASE and the full model type extends it. Same guarantee (a plugin handle has no mutator to
+! call), opposite direction. The type-bound implementations below therefore take class(plume_data_view)
+! for the shared procedures; a model-side plume_data handle still resolves them via inheritance.
+type, public :: plume_data_view
     type(c_ptr) :: impl = c_null_ptr
     logical :: is_finalised = .false.
 contains
-    procedure :: initialise          => plume_data_create_handle
-    procedure :: initialise_from_ptr => plume_data_create_handle_from_ptr
+    procedure :: initialise_from_ptr    => plume_data_create_handle_from_ptr
+
+    procedure :: get_int                => plume_data_get_int
+    procedure :: get_bool               => plume_data_get_bool
+    procedure :: get_float              => plume_data_get_float
+    procedure :: get_double             => plume_data_get_double
+    procedure :: get_shared_atlas_field => plume_data_get_shared_atlas_field
+
+    procedure :: write_int               => plume_data_write_int
+    procedure :: write_bool              => plume_data_write_bool
+    procedure :: write_float             => plume_data_write_float
+    procedure :: write_double            => plume_data_write_double
+    procedure :: write_atlas_field_copy  => plume_data_write_atlas_field_copy
+    procedure :: write_atlas_field_scope => plume_data_write_atlas_field_scope
+
+    procedure :: print    => plume_data_print
+    procedure :: finalise => plume_data_delete_handle
+end type
+
+
+! PLUME data — the model-facing handle. Extends plume_data_view with the model-only mutators
+! (parameter creation, provisioning, in-place updates and write-back reconciliation).
+type, extends(plume_data_view), public :: plume_data
+contains
+    procedure :: initialise                 => plume_data_create_handle
 
     procedure :: create_int                 => plume_data_create_int
     procedure :: create_bool                => plume_data_create_bool
@@ -37,28 +71,26 @@ contains
     procedure :: update_int                 => plume_data_update_int
     procedure :: update_bool                => plume_data_update_bool
     procedure :: update_float               => plume_data_update_float
-    procedure :: update_double              => plume_data_update_double    
-    
-    procedure :: get_int                    => plume_data_get_int
-    procedure :: get_bool                   => plume_data_get_bool
-    procedure :: get_float                  => plume_data_get_float
-    procedure :: get_double                 => plume_data_get_double
-    procedure :: get_shared_atlas_field     => plume_data_get_shared_atlas_field
+    procedure :: update_double              => plume_data_update_double
 
     procedure :: set_updated                => plume_data_set_updated
-
-    procedure :: write_int                  => plume_data_write_int
-    procedure :: write_bool                 => plume_data_write_bool
-    procedure :: write_float                => plume_data_write_float
-    procedure :: write_double               => plume_data_write_double
-    procedure :: write_atlas_field          => plume_data_write_atlas_field
 
     procedure :: pending_writebacks         => plume_data_pending_writebacks
     procedure :: acknowledge_writeback      => plume_data_acknowledge_writeback
 
-    procedure :: print => plume_data_print
-    procedure :: finalise => plume_data_delete_handle
+end type
 
+
+! PLUME write scope — an RAII handle for an in-place, copy-free Atlas write-back, the Fortran analogue of the C++
+! WriteScope. Obtained via plume_data_view%write_atlas_field_scope(name, scope).
+! Contrast write_atlas_field_copy, which submits a separate field whose contents are copied in.
+type, public :: plume_write_scope
+    type(c_ptr) :: scope     = c_null_ptr  ! opaque plume::data::WriteScope*
+    type(c_ptr) :: field_ptr = c_null_ptr  ! staged atlas::Field::Implementation* (the model's own buffer)
+contains
+    procedure :: view   => plume_write_scope_view
+    procedure :: commit => plume_write_scope_commit
+    final     :: plume_write_scope_final
 end type
 
 
@@ -252,6 +284,23 @@ function plume_data_get_shared_atlas_field_interf(handle_impl, name, field_c_ptr
   integer(c_int) :: err
 end function
 
+function plume_data_write_scope_begin_interf(handle_impl, name, scope_ptr, field_c_ptr) result(err) &
+  & bind(C,name="plume_data_write_scope_begin")
+  use iso_c_binding, only: c_ptr, c_char, c_int
+  type(c_ptr), intent(in), value :: handle_impl
+  character(c_char), dimension(*) :: name
+  type(c_ptr), intent(out) :: scope_ptr
+  type(c_ptr), intent(out) :: field_c_ptr
+  integer(c_int) :: err
+end function
+
+function plume_data_write_scope_commit_interf(scope_ptr) result(err) &
+  & bind(C,name="plume_data_write_scope_commit")
+  use iso_c_binding, only: c_ptr, c_int
+  type(c_ptr), intent(in), value :: scope_ptr
+  integer(c_int) :: err
+end function
+
 function plume_data_get_int_interf( handle_impl, name, val ) result (err) &
   & bind(C,name="plume_data_get_int")
   use iso_c_binding, only: c_ptr, c_char, c_int
@@ -379,14 +428,14 @@ end function
 
 function plume_data_create_handle_from_ptr( handle, data_c_ptr ) result(err)
   use iso_c_binding, only: c_ptr
-  class(plume_data), intent(inout) :: handle
+  class(plume_data_view), intent(inout) :: handle
   type(c_ptr), intent(in), value :: data_c_ptr
   integer :: err
   err = plume_data_create_handle_from_ptr_interf(handle%impl, data_c_ptr)
 end function
 
 function plume_data_delete_handle( handle ) result(err)
-  class(plume_data), intent(inout) :: handle
+  class(plume_data_view), intent(inout) :: handle
   integer :: err
   if (handle%is_finalised .eqv. .false.) then
     err = plume_data_delete_handle_interf(handle%impl)
@@ -525,21 +574,31 @@ end function
 ! this function returns a field from a requested field name
 function plume_data_get_shared_atlas_field( handle, name, field ) result (err)
   use iso_c_binding, only: c_ptr, c_char, c_int
-  class(plume_data), intent(inout) :: handle
+  ! NOTE (PLUME-75): this returns a fully mutable atlas_field that shares the model's buffer. Unlike the C++
+  ! path (where getParam yields a read-only plume::data::FieldView), the read-only field guarantee is NOT enforced
+  ! here — a Fortran plugin can still mutate the field in place and bypass the write-back ledger. Extending the
+  ! enforcement to the Fortran path is a possible follow-up.
+  class(plume_data_view), intent(inout) :: handle
   character(*), intent(in) :: name
-  type(atlas_field), intent(inout) :: field
+  type(atlas_field), intent(out) :: field
   type(c_ptr) :: field_ptr
   integer(c_int) :: err
 
-  ! Set the internal c_ptr of the field
+  ! Wrap the borrowed (model-owned) FieldImpl with the canonical atlas cptr constructor: atlas_Field(cptr)
+  ! attaches a reference, and the return() inside the constructor balances its own function result, so the
+  ! assignment below leaves `field` holding exactly one reference to the model buffer. `field` is an
+  ! intent(out) dummy (the caller's variable), NOT a function result, so we must NOT call field%return()
+  ! here — the `x = atlas_Field(cptr); call x%return()` idiom is only correct for a function result. An extra
+  ! return() would over-detach and, once the caller finalises `field`, drop the model buffer to zero owners
+  ! and free it prematurely (a finaliser-dependent fault, so masked where FCKIT_HAVE_FINAL=0).
   err = plume_data_get_shared_atlas_field_interf(handle%impl, c_str(name), field_ptr)
-  call field%reset_c_ptr(field_ptr)
+  field = atlas_Field(field_ptr)
 end function
 
 ! this function returns a metadata parameter (int)
 function plume_data_get_int( handle, name, val ) result (err)
   use iso_c_binding, only: c_int
-  class(plume_data), intent(inout) :: handle
+  class(plume_data_view), intent(inout) :: handle
   character(*), intent(in) :: name
   integer(c_int), intent(inout) :: val
   integer(c_int) :: err
@@ -548,7 +607,7 @@ end function
 
 function plume_data_get_bool( handle, name, val ) result (err)
   use iso_c_binding, only: c_bool, c_int
-  class(plume_data), intent(inout) :: handle
+  class(plume_data_view), intent(inout) :: handle
   character(*), intent(in) :: name
   logical(c_bool), intent(inout) :: val
   integer(c_int) :: err
@@ -557,7 +616,7 @@ end function
 
 function plume_data_get_float( handle, name, val ) result (err)
   use iso_c_binding, only: c_float, c_int
-  class(plume_data), intent(inout) :: handle
+  class(plume_data_view), intent(inout) :: handle
   character(*), intent(in) :: name
   real(c_float), intent(inout) :: val
   integer(c_int) :: err
@@ -566,7 +625,7 @@ end function
 
 function plume_data_get_double( handle, name, val ) result (err)
   use iso_c_binding, only: c_double, c_int
-  class(plume_data), intent(inout) :: handle
+  class(plume_data_view), intent(inout) :: handle
   character(*), intent(in) :: name
   real(c_double), intent(inout) :: val
   integer(c_int) :: err
@@ -574,7 +633,7 @@ function plume_data_get_double( handle, name, val ) result (err)
 end function
 
 function plume_data_print( handle ) result(err)
-  class(plume_data), intent(inout) :: handle
+  class(plume_data_view), intent(inout) :: handle
   integer :: err
   err = plume_data_print_interf(handle%impl)
 end function
@@ -598,7 +657,7 @@ end function
 
 function plume_data_write_int( handle, name, val ) result(err)
   use iso_c_binding, only: c_int
-  class(plume_data), intent(inout) :: handle
+  class(plume_data_view), intent(inout) :: handle
   character(kind=c_char,len=*), intent(in) :: name
   integer(c_int), intent(in) :: val
   integer(c_int) :: err
@@ -607,7 +666,7 @@ end function
 
 function plume_data_write_bool( handle, name, val ) result(err)
   use iso_c_binding, only: c_bool, c_int
-  class(plume_data), intent(inout) :: handle
+  class(plume_data_view), intent(inout) :: handle
   character(kind=c_char,len=*), intent(in) :: name
   logical(c_bool), intent(in) :: val
   integer(c_int) :: err
@@ -616,7 +675,7 @@ end function
 
 function plume_data_write_float( handle, name, val ) result(err)
   use iso_c_binding, only: c_float, c_int
-  class(plume_data), intent(inout) :: handle
+  class(plume_data_view), intent(inout) :: handle
   character(kind=c_char,len=*), intent(in) :: name
   real(c_float), intent(in) :: val
   integer(c_int) :: err
@@ -625,21 +684,72 @@ end function
 
 function plume_data_write_double( handle, name, val ) result(err)
   use iso_c_binding, only: c_double, c_int
-  class(plume_data), intent(inout) :: handle
+  class(plume_data_view), intent(inout) :: handle
   character(kind=c_char,len=*), intent(in) :: name
   real(c_double), intent(in) :: val
   integer(c_int) :: err
   err = plume_data_write_double_interf(handle%impl, c_str(name), val)
 end function
 
-function plume_data_write_atlas_field( handle, name, value ) result(err)
+function plume_data_write_atlas_field_copy( handle, name, value ) result(err)
   use iso_c_binding, only: c_int
-  class(plume_data), intent(inout) :: handle
+  class(plume_data_view), intent(inout) :: handle
   character(kind=c_char,len=*), intent(in) :: name
   type(atlas_Field), intent(in) :: value
   integer(c_int) :: err
   err = plume_data_write_atlas_field_interf(handle%impl, c_str(name), value%c_ptr())
 end function
+
+subroutine plume_data_write_atlas_field_scope( handle, name, scope, err )
+  use iso_c_binding, only: c_char, c_int
+  class(plume_data_view), intent(inout) :: handle
+  character(kind=c_char,len=*), intent(in) :: name
+  type(plume_write_scope), intent(out) :: scope
+  integer(c_int), intent(out), optional :: err
+  integer(c_int) :: local_err
+  local_err = plume_data_write_scope_begin_interf(handle%impl, c_str(name), scope%scope, scope%field_ptr)
+  if (present(err)) err = local_err
+end subroutine
+
+! Alias the staged model buffer into an atlas_field for in-place mutation (mirrors get_shared_atlas_field).
+subroutine plume_write_scope_view( scope, field )
+  class(plume_write_scope), intent(inout) :: scope
+  type(atlas_field), intent(out) :: field
+  ! Wrap the borrowed (model-owned) FieldImpl with the canonical atlas cptr constructor: atlas_Field(cptr)
+  ! attaches a reference, and the return() inside the constructor balances its own function result, so the
+  ! assignment below leaves `field` holding exactly one reference to the model buffer. `field` is an
+  ! intent(out) dummy (the caller's variable), NOT a function result, so we must NOT call field%return()
+  ! here — the `x = atlas_Field(cptr); call x%return()` idiom is only correct for a function result. An extra
+  ! return() would over-detach and, once the caller finalises `field`, drop the model buffer to zero owners
+  ! and free it prematurely (a finaliser-dependent fault, so masked where FCKIT_HAVE_FINAL=0).
+  field = atlas_Field(scope%field_ptr)
+end subroutine
+
+! Commit the write-back early and neutralise the scope so the final binding does not commit it a second time.
+function plume_write_scope_commit( scope ) result(err)
+  use iso_c_binding, only: c_int, c_associated, c_null_ptr
+  class(plume_write_scope), intent(inout) :: scope
+  integer(c_int) :: err
+  err = 0_c_int
+  if (c_associated(scope%scope)) then
+    err = plume_data_write_scope_commit_interf(scope%scope)
+    scope%scope     = c_null_ptr
+    scope%field_ptr = c_null_ptr
+  end if
+end function
+
+! Scope-exit finaliser — commits any un-committed write-back (the RAII auto-commit). Best-effort: a final procedure
+! cannot return a status, so a commit error here is dropped; call commit() explicitly to observe the status.
+subroutine plume_write_scope_final( scope )
+  use iso_c_binding, only: c_int, c_associated, c_null_ptr
+  type(plume_write_scope), intent(inout) :: scope
+  integer(c_int) :: err
+  if (c_associated(scope%scope)) then
+    err = plume_data_write_scope_commit_interf(scope%scope)
+    scope%scope     = c_null_ptr
+    scope%field_ptr = c_null_ptr
+  end if
+end subroutine
 
 function plume_data_pending_writebacks( handle ) result(pending_str)
   use iso_c_binding, only: c_ptr

--- a/src/plume/api/plume_manager.F90
+++ b/src/plume/api/plume_manager.F90
@@ -200,7 +200,7 @@ function plume_manager_active_fields(handle) result(fields_str)
     call plume_free_string(fields_ptr)
 end function
 
-! TODO: this really need to be checked!! not testing for errors, but returns a char*
+! TODO: this really need to be checked!! not testing for errors, but returns a fckit_configuration
 function plume_manager_active_fields_catalogue(handle) result(active_catalogue)
     use iso_c_binding, only: c_ptr
     class(plume_manager), intent(inout) :: handle
@@ -208,12 +208,14 @@ function plume_manager_active_fields_catalogue(handle) result(active_catalogue)
     type(c_ptr) :: cat_ptr
     integer :: err
 
-    ! init
-    active_catalogue = fckit_configuration()
-
     ! get only the active part of the catalogue
     err = plume_manager_active_fields_catalogue_interf(handle%impl, cat_ptr)
-    call active_catalogue%reset_c_ptr(cat_ptr)
+
+    ! the C side hands back a newly allocated Configuration (caller-owned), so
+    ! take ownership (own=.true. installs the deleter) via the canonical ctor,
+    ! which also calls return() to balance the reference on output.
+    active_catalogue = fckit_configuration(cat_ptr, own=.true.)
+    call active_catalogue%return()
 end function
 
 function plume_manager_is_param_requested(handle, name, is_param) result(err)

--- a/src/plume/data/FieldAccess.cc
+++ b/src/plume/data/FieldAccess.cc
@@ -1,0 +1,62 @@
+/*
+ * (C) Copyright 2023- ECMWF.
+ *
+ * This software is licensed under the terms of the Apache Licence Version 2.0
+ * which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * In applying this licence, ECMWF does not waive the privileges and immunities
+ * granted to it by virtue of its status as an intergovernmental organisation nor
+ * does it submit to any jurisdiction.
+ */
+#include <utility>
+
+#include "plume/coupling/WriteBackLedger.h"
+#include "plume/data/FieldAccess.h"
+
+namespace plume {
+namespace data {
+
+// -----------------------------------------------------------------------------
+// WriteScope — the in-place write-back RAII primitive (declared in FieldAccess.h).
+
+// The scope is deliberately decoupled from ModelData: ModelData::writeParam has already staged the write and resolved
+// the buffer, so the scope only borrows the ledger (to report an aborted write) and the model buffer pointer.
+
+WriteScope::WriteScope(coupling::WriteBackLedger& ledger, std::string name, atlas::Field& field) :
+    ledger_(&ledger), name_(std::move(name)), field_(&field) {}
+
+WriteScope::WriteScope(WriteScope&& other) noexcept :
+    ledger_(other.ledger_),
+    name_(std::move(other.name_)),
+    field_(other.field_),
+    valid_(other.valid_),
+    committed_(other.committed_) {
+    // Neutralise the moved-from scope so its destructor neither aborts nor reports.
+    other.ledger_    = nullptr;
+    other.field_     = nullptr;
+    other.valid_     = false;
+    other.committed_ = true;
+}
+
+WriteScope::~WriteScope() {
+    if (ledger_ != nullptr && !committed_) {
+        valid_ = false;  // poison any outstanding FieldWriter before reporting
+        try {
+            ledger_->reportError(name_, "write scope destroyed without commit()");
+        }
+        catch (...) {
+            // A destructor must never throw; the ledger error is best-effort here.
+        }
+    }
+}
+
+void WriteScope::commit() {
+    // The in-place mutation has already landed in the model buffer through the FieldWriter; there is no
+    // separate buffer to flush. Committing simply poisons the handle and leaves the ledger slot STAGED for
+    // the model to flush at end of cycle — exactly like the value-based writeParam path.
+    valid_     = false;
+    committed_ = true;
+}
+
+}  // namespace data
+}  // namespace plume

--- a/src/plume/data/FieldAccess.cc
+++ b/src/plume/data/FieldAccess.cc
@@ -12,6 +12,7 @@
 
 #include "plume/coupling/WriteBackLedger.h"
 #include "plume/data/FieldAccess.h"
+#include "plume/data/ParameterValue.h"
 
 namespace plume {
 namespace data {
@@ -19,23 +20,23 @@ namespace data {
 // -----------------------------------------------------------------------------
 // WriteScope — the in-place write-back RAII primitive (declared in FieldAccess.h).
 
-// The scope is deliberately decoupled from ModelData: ModelData::writeParam has already staged the write and resolved
-// the buffer, so the scope only borrows the ledger (to report an aborted write) and the model buffer pointer.
-
-WriteScope::WriteScope(coupling::WriteBackLedger& ledger, std::string name, atlas::Field& field) :
-    ledger_(&ledger), name_(std::move(name)), field_(&field) {}
+WriteScope::WriteScope(coupling::WriteBackLedger& ledger, std::string name,
+                       ParameterValueTyped<atlas::Field>& paramValue) :
+    ledger_(&ledger), name_(std::move(name)), field_(&paramValue.getSettableField()), paramValue_(&paramValue) {}
 
 WriteScope::WriteScope(WriteScope&& other) noexcept :
     ledger_(other.ledger_),
     name_(std::move(other.name_)),
     field_(other.field_),
+    paramValue_(other.paramValue_),
     valid_(other.valid_),
     committed_(other.committed_) {
     // Neutralise the moved-from scope so its destructor neither aborts nor reports.
-    other.ledger_    = nullptr;
-    other.field_     = nullptr;
-    other.valid_     = false;
-    other.committed_ = true;
+    other.ledger_     = nullptr;
+    other.field_      = nullptr;
+    other.paramValue_ = nullptr;
+    other.valid_      = false;
+    other.committed_  = true;
 }
 
 WriteScope::~WriteScope() {
@@ -51,11 +52,16 @@ WriteScope::~WriteScope() {
 }
 
 void WriteScope::commit() {
-    // The in-place mutation has already landed in the model buffer through the FieldWriter; there is no
-    // separate buffer to flush. Committing simply poisons the handle and leaves the ledger slot STAGED for
-    // the model to flush at end of cycle — exactly like the value-based writeParam path.
+    if (committed_) {
+        return;  // idempotent: already finalised
+    }
+    // Moved-from scopes are an empty husk with nothing to commit — misuse, so this stays a loud failure.
+    ASSERT_MSG(paramValue_ != nullptr,
+               "WriteScope::commit() called on a moved-from scope for parameter '" + name_ + "'");
     valid_     = false;
     committed_ = true;
+    // Notifies any active observers if the parameter is an actively-observed IParameterObservable.
+    paramValue_->setUpdated(true);
 }
 
 }  // namespace data

--- a/src/plume/data/FieldAccess.h
+++ b/src/plume/data/FieldAccess.h
@@ -1,0 +1,200 @@
+/*
+ * (C) Copyright 2023- ECMWF.
+ *
+ * This software is licensed under the terms of the Apache Licence Version 2.0
+ * which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * In applying this licence, ECMWF does not waive the privileges and immunities
+ * granted to it by virtue of its status as an intergovernmental organisation nor
+ * does it submit to any jurisdiction.
+ */
+#pragma once
+
+#include <ostream>
+#include <string>
+
+#include "eckit/exception/Exceptions.h"
+
+#include "atlas/array/Array.h"
+#include "atlas/array/DataType.h"
+#include "atlas/field/Field.h"
+#include "atlas/functionspace/FunctionSpace.h"
+#include "atlas/util/Metadata.h"
+
+namespace plume {
+
+namespace coupling {
+class WriteBackLedger;  // forward declaration — a WriteScope reports an aborted write back to the ledger.
+}
+
+namespace data {
+
+// Plugin-facing field access wrappers.
+//
+// This header groups the narrow, plugin-facing wrappers over a model field: FieldView is the read-only surface
+// returned by getParam; FieldWriter is its write-path sibling returned by writeParam.
+// Note this is distinct from FieldProvider, which handles the model-side field-derivation strategy machinery.
+
+/**
+ * @brief Read-only, non-owning view over a model field.
+ *
+ * FieldView exposes only const access to the underlying data (via `operator const atlas::array::Array&`) plus
+ * read-only metadata, so plugins can read model fields but cannot mutate them or copy out a mutable handle. It is the
+ * return type of getParam<atlas::Field> on the plugin-facing ModelDataView.
+ *
+ * Because mutability of an atlas view is decided by the const-ness of its source, the only conversion offered here is
+ * to `const atlas::array::Array&`: `atlas::array::make_view<T, Rank>(fieldView)` keeps working unchanged but yields an
+ * `ArrayView<const T, Rank>` (read-only) even when the caller does not write `const`. There is deliberately NO
+ * conversion to `atlas::Field` or to a mutable `atlas::array::Array&`, and no raw-field escape hatch, so a plugin
+ * cannot copy out a mutable handle and bypass the write-back ledger. If a plugin does need a mutable field (e.g. for
+ * a read-modify-write), it calls clone() to get an independent deep copy and can hand the result to writeParam().
+ *
+ * @note Scope: this read-only guarantee is C++-ONLY. It applies to plugins holding a ModelDataView (getParam returns
+ *       a FieldView). The Fortran/C plugin path (plume_data_get_shared_atlas_field) still hands back a fully mutable
+ *       atlas_field sharing the model's buffer. Extending this enforcement to Fortran can follow-up.
+ *
+ * @note Future extension: the backing handle is an `atlas::Field` today, but this is an implementation detail. If
+ *       Plume grows support for other field representations, FieldView can become a builder-style wrapper constructed
+ *       from any supported handle type without changing its read-only public surface. The class name is deliberately
+ *       representation-agnostic (FieldView, not ConstAtlasFieldView): read-only-ness is its identity, not a variant.
+ */
+class FieldView {
+public:
+    /// Wraps an atlas::Field. The copy is a cheap shared-handle copy (shares the underlying FieldImpl/array).
+    explicit FieldView(const atlas::Field& field) : field_(field) {}
+
+    /// The one conversion that matters: read-only array access, so atlas::array::make_view works unchanged.
+    operator const atlas::array::Array&() const { return field_.array(); }
+
+    // --- Read-only metadata pass-throughs -----------------------------------
+    const std::string& name() const { return field_.name(); }
+    const atlas::array::ArrayShape& shape() const { return field_.shape(); }
+    atlas::idx_t shape(atlas::idx_t i) const { return field_.shape(i); }
+    atlas::array::DataType datatype() const { return field_.datatype(); }
+    atlas::idx_t rank() const { return field_.rank(); }
+    size_t size() const { return field_.size(); }
+    atlas::idx_t levels() const { return field_.levels(); }
+    const atlas::util::Metadata& metadata() const { return field_.metadata(); }
+    const atlas::FunctionSpace& functionspace() const { return field_.functionspace(); }
+    atlas::Field clone() const { return field_.clone(); }
+
+    /// Read-only diagnostic streaming — mirrors atlas::Field's operator<< (prints field metadata, never data).
+    friend std::ostream& operator<<(std::ostream& os, const FieldView& fieldView) { return os << fieldView.field_; }
+
+    // Deliberately NOT provided: operator atlas::Field / const atlas::Field& field() / operator atlas::array::Array& /
+    // mutable metadata() — any of these would let a plugin copy out a handle SHARING the model's FieldImpl and mutate
+    // it in place, bypassing the write-back ledger. clone() is the sanctioned way to get a mutable field from a View.
+
+private:
+    atlas::Field field_;  // shares the model's FieldImpl (cheap handle copy)
+};
+
+/**
+ * @brief Mutable, poison-after-scope write handle over a model field — the write-path sibling of FieldView.
+ *
+ * FieldWriter is what the in-place write-back path hands to an author (see WriteScope / the callable writeParam
+ * overload). It exposes exactly one conversion — `operator atlas::array::Array&` — so `atlas::array::make_view<T,
+ * Rank>(fieldWriter)` yields a MUTABLE view aliasing the model's own buffer, letting the plugin read-modify-write in
+ * place with no scratch allocation. The mutation is only legal because the owning WriteScope has already staged the
+ * write with the authorisation ledger; an unauthorised plugin never obtains a FieldWriter at all.
+ *
+ * Two guardrails keep an already-authorised author on the correct path:
+ *   - The handle is non-copyable and non-movable, so it cannot be stashed by value (`auto stolen = f;` does not
+ *     compile) and cannot outlive the callback it is passed into.
+ *   - Access is gated by a validity flag OWNED BY the WriteScope. On commit/scope-exit the scope flips the flag, so
+ *     re-using a captured `FieldWriter&` after the scope throws eckit::BadValue instead of silently touching freed
+ *     lifecycle state.
+ *
+ * Residual gap (deliberately out of scope): an ArrayView taken from a FieldWriter *inside* the scope holds a raw
+ * pointer into live model memory; poisoning the flag cannot reach it. This is the determined-author stash, not the
+ * casual one — closing it would need a per-access indirection atlas does not provide.
+ */
+class FieldWriter {
+public:
+    FieldWriter(const FieldWriter&)            = delete;
+    FieldWriter& operator=(const FieldWriter&) = delete;
+    FieldWriter(FieldWriter&&)                 = delete;
+    FieldWriter& operator=(FieldWriter&&)      = delete;
+
+    /// The one conversion that matters: mutable array access, so atlas::array::make_view yields a writable view.
+    operator atlas::array::Array&() {
+        ensureValid();
+        return field_.array();
+    }
+
+    // --- Read-only metadata pass-throughs -----------------------------------
+    const std::string& name() const { return field_.name(); }
+    const atlas::array::ArrayShape& shape() const { return field_.shape(); }
+    atlas::idx_t shape(atlas::idx_t i) const { return field_.shape(i); }
+    atlas::array::DataType datatype() const { return field_.datatype(); }
+    atlas::idx_t rank() const { return field_.rank(); }
+    size_t size() const { return field_.size(); }
+    atlas::idx_t levels() const { return field_.levels(); }
+    const atlas::util::Metadata& metadata() const { return field_.metadata(); }
+    const atlas::FunctionSpace& functionspace() const { return field_.functionspace(); }
+    atlas::Field clone() const { return field_.clone(); }
+
+private:
+    friend class WriteScope;  // only a WriteScope hands out a FieldWriter into its staged buffer.
+    FieldWriter(atlas::Field& field, const bool& valid) : field_(field), valid_(valid) {}
+
+    void ensureValid() const {
+        if (!valid_) {
+            throw eckit::BadValue("plume::data::FieldWriter used outside its write scope", Here());
+        }
+    }
+
+    atlas::Field& field_;  // the model's own buffer (aliased, not copied, typically borrowed from the scope)
+    const bool& valid_;    // owned by the WriteScope; flipped to false on commit/scope-exit
+};
+
+/**
+ * @brief Move-only RAII scope for an in-place, copy-free write-back.
+ *
+ * A WriteScope is obtained from the arity overload writeParam(name) (no value argument) on ModelData / ModelDataView.
+ * writeParam stages the write with the authorisation ledger (throwing if the plugin is not authorised or the
+ * single-writer policy is violated) before handing back the scope; field() then hands a FieldWriter aliasing
+ * the model's own buffer so the author can read-modify-write in place; commit() finalises the scope. If the scope is
+ * destroyed without commit() (e.g. the author forgot, or the body threw), the destructor poisons the handle and
+ * reports the failure to the ledger so the missing write is not silently lost.
+ *
+ * @code
+ *   auto w = data.writeParam("swh");                          // stage → WriteScope
+ *   auto v = atlas::array::make_view<double, 2>(w.field());   // mutable view over the model buffer
+ *   v(i, j) *= 1.05;                                          // in-place read-modify-write
+ *   w.commit();                                               // finalise (dtor aborts+reports if forgotten)
+ * @endcode
+ *
+ * This is the manual-control escape hatch; most plugin authors use the callable writeParam(name, body) overload, which
+ * owns a WriteScope internally and guarantees stage → run → commit / abort-on-throw.
+ */
+class WriteScope {
+public:
+    WriteScope(WriteScope&& other) noexcept;
+    WriteScope& operator=(WriteScope&&)      = delete;
+    WriteScope(const WriteScope&)            = delete;
+    WriteScope& operator=(const WriteScope&) = delete;
+    ~WriteScope();
+
+    /// Hands out a mutable, poison-after-scope handle aliasing the staged model buffer.
+    FieldWriter field() { return FieldWriter{*field_, valid_}; }
+
+    /// Finalises the scope: poison any outstanding FieldWriter and leave the ledger slot staged for the model flush.
+    void commit();
+
+private:
+    // Only ModelData::writeParam(name) constructs a WriteScope, and only after it has staged the write with the
+    // ledger — so a scope can never exist for an unauthorised or unstaged write. The scope itself needs no access
+    // to ModelData's internals: it borrows the already-resolved buffer and the ledger (for the abort report).
+    friend class ModelData;
+    WriteScope(coupling::WriteBackLedger& ledger, std::string name, atlas::Field& field);
+
+    coupling::WriteBackLedger* ledger_;  // null after a move; guards the destructor abort path
+    std::string name_;
+    atlas::Field* field_;    // the staged model buffer (owned by the model, aliased here)
+    bool valid_     = true;  // referenced by every FieldWriter this scope hands out
+    bool committed_ = false;
+};
+
+}  // namespace data
+}  // namespace plume

--- a/src/plume/data/FieldAccess.h
+++ b/src/plume/data/FieldAccess.h
@@ -29,6 +29,10 @@ class WriteBackLedger;  // forward declaration — a WriteScope reports an abort
 
 namespace data {
 
+class IParameterValue;  // forward declaration — a WriteScope signals a committed write back to its parameter.
+template <typename T>
+class ParameterValueTyped;  // forward declaration — a WriteScope resolves its settable field from this.
+
 // Plugin-facing field access wrappers.
 //
 // This header groups the narrow, plugin-facing wrappers over a model field: FieldView is the read-only surface
@@ -154,9 +158,9 @@ private:
  * A WriteScope is obtained from the arity overload writeParam(name) (no value argument) on ModelData / ModelDataView.
  * writeParam stages the write with the authorisation ledger (throwing if the plugin is not authorised or the
  * single-writer policy is violated) before handing back the scope; field() then hands a FieldWriter aliasing
- * the model's own buffer so the author can read-modify-write in place; commit() finalises the scope. If the scope is
- * destroyed without commit() (e.g. the author forgot, or the body threw), the destructor poisons the handle and
- * reports the failure to the ledger so the missing write is not silently lost.
+ * the model's own buffer so the author can read-modify-write in place; commit() finalises the scope and notifies any
+ * active observers. If the scope is destroyed without commit() (e.g. the author forgot, or the body threw), the
+ * destructor poisons the handle and reports the failure to the ledger so the missing write is not silently lost.
  *
  * @code
  *   auto w = data.writeParam("swh");                          // stage → WriteScope
@@ -165,8 +169,7 @@ private:
  *   w.commit();                                               // finalise (dtor aborts+reports if forgotten)
  * @endcode
  *
- * This is the manual-control escape hatch; most plugin authors use the callable writeParam(name, body) overload, which
- * owns a WriteScope internally and guarantees stage → run → commit / abort-on-throw.
+ * This is the manual-control escape hatch; most plugin authors use the callable writeParam(name, body) overload.
  */
 class WriteScope {
 public:
@@ -179,20 +182,25 @@ public:
     /// Hands out a mutable, poison-after-scope handle aliasing the staged model buffer.
     FieldWriter field() { return FieldWriter{*field_, valid_}; }
 
-    /// Finalises the scope: poison any outstanding FieldWriter and leave the ledger slot staged for the model flush.
+    /**
+     * @brief Finalises the scope: poisons any outstanding FieldWriter and marks the parameter updated.
+     *
+     * It leaves the ledger slot staged for the model to flush. A repeat call is a no-op.
+     */
     void commit();
 
 private:
     // Only ModelData::writeParam(name) constructs a WriteScope, and only after it has staged the write with the
-    // ledger — so a scope can never exist for an unauthorised or unstaged write. The scope itself needs no access
-    // to ModelData's internals: it borrows the already-resolved buffer and the ledger (for the abort report).
+    // ledger — so a scope can never exist for an unauthorised or unstaged write. It borrows the ledger and a non-owning
+    // pointer to the parameter, resolving the model buffer from it.
     friend class ModelData;
-    WriteScope(coupling::WriteBackLedger& ledger, std::string name, atlas::Field& field);
+    WriteScope(coupling::WriteBackLedger& ledger, std::string name, ParameterValueTyped<atlas::Field>& paramValue);
 
     coupling::WriteBackLedger* ledger_;  // null after a move; guards the destructor abort path
     std::string name_;
-    atlas::Field* field_;    // the staged model buffer (owned by the model, aliased here)
-    bool valid_     = true;  // referenced by every FieldWriter this scope hands out
+    atlas::Field* field_;          // the staged model buffer (owned by the model, aliased here)
+    IParameterValue* paramValue_;  // the param updates propagate on commit if it is actively observed
+    bool valid_     = true;        // referenced by every FieldWriter this scope hands out
     bool committed_ = false;
 };
 

--- a/src/plume/data/ModelData.cc
+++ b/src/plume/data/ModelData.cc
@@ -14,6 +14,7 @@
 #include <plume/data/ModelData.h>
 
 #include "plume/coupling/WriteBackLedger.h"
+#include "plume/data/ModelDataView.h"
 
 
 namespace plume {
@@ -26,9 +27,9 @@ ModelData::ModelData() {
 }
 
 ModelData::~ModelData() {
-    // Only the model-facing ModelData instance owns the detach callback.
+    // Only the ledger-owning instance (the model-facing ModelData that attached it) may detach.
     // Plugin-facing (filtered) views may carry a ledger pointer but must not detach or warn.
-    if (ledger_ && modelFacing_) {
+    if (ledger_ && ownsLedger_) {
         eckit::Log::warning() << "ModelData destroyed with write-back ledger still attached — detaching to avoid a "
                                  "dangling callback. Manager::teardown() may not have been called."
                               << std::endl;
@@ -38,27 +39,37 @@ ModelData::~ModelData() {
 }
 
 
-// Get a subset of the ModelData
-ModelData ModelData::filter(std::set<std::string> params, const std::string& consumer) const {
-    ModelData filteredData{PluginFacingTag{}};
+// Get a subset of the ModelData as a plugin-facing view
+ModelDataView ModelData::filter(std::set<std::string> params, const std::string& consumer) const {
+    ModelData filteredData;
+    // A plugin-facing view carries only parameter values — the strategy registries are model-side machinery
+    // (creating/updating derived params) that plugins must not touch, so drop what the default constructor registered.
+    // Could use a ctor with a tag to fully avoid registering strategies if this becomes heavy or with side effects.
+    filteredData.strategyRegistry_.clear();
+    filteredData.strategyHelpers_.clear();
     filteredData.ledger_                 = ledger_;   // propagate ledger so plugins can call writeParam
     filteredData.consumer_               = consumer;  // tag this view with the consuming plugin's name
     std::vector<std::string> availParams = getAvailableValues();
     for (const auto& key : params) {
         if (std::find(availParams.begin(), availParams.end(), key) != availParams.end()) {
             auto entry = valueMap_.at(key);
+            // (PLUME-82) shared_ptr copy → the plugin-facing view co-owns this parameter (and its
+            // atlas::Field) with the model-facing ModelData. See ModelDataView's PLUME-82 note: this shared
+            // ownership is why PluginCore::releaseData() must drop the view at teardown. A non-owning
+            // observer view would remove that coupling.
             filteredData.valueMap_.insert(std::make_pair(key, entry));
         }
         else {
             eckit::Log::info() << "Parameter: " << key << " NOT found in Data! " << std::endl;
         }
     }
-    return filteredData;
+    // Hand the built subset to the plugin-facing view. ModelData is intentionally non-movable so this is a cheap copy.
+    return ModelDataView{filteredData};
 }
 
 
 // Return a subset of the ModelData (from catalogue)
-ModelData ModelData::filter(ParameterCatalogue params, const std::string& consumer) const {
+ModelDataView ModelData::filter(ParameterCatalogue params, const std::string& consumer) const {
     return filter(params.getParamNames(), consumer);
 }
 
@@ -139,14 +150,19 @@ std::vector<std::string> ModelData::listAvailableParameters(std::string type_str
 void ModelData::attachWritebackLedger(coupling::WriteBackLedger* ledger) {
     ASSERT_MSG(ledger != nullptr, "ModelData::attachWritebackLedger: ledger must not be null");
     ASSERT_MSG(ledger_ == nullptr, "ModelData::attachWritebackLedger: a ledger is already attached");
-    ledger_ = ledger;
+    ledger_     = ledger;
+    ownsLedger_ = true;  // record ownership where it is acquired — only this instance may detach
     ledger_->setDetachCallback([this]() { ledger_ = nullptr; });
 }
 
 void ModelData::detachWritebackLedger() {
-    if (ledger_) {
+    // Guard the ownership invariant at the point of action: only the instance that attached the ledger
+    // may clear its callback. A non-owning (filtered) view holds a borrowed ledger_ pointer and must not
+    // touch the shared callback, so detach is a no-op for it.
+    if (ledger_ && ownsLedger_) {
         ledger_->setDetachCallback(nullptr);  // prevent double-null when ledger is later destroyed
-        ledger_ = nullptr;
+        ledger_     = nullptr;
+        ownsLedger_ = false;
     }
 }
 
@@ -165,6 +181,36 @@ void ModelData::acknowledgeWriteback(const std::string& name) {
         throw eckit::BadValue("ModelData::acknowledgeWriteback: write-back ledger not attached", Here());
     }
     ledger_->acknowledgeWriteback(name);
+}
+
+// ---------------------------------------------------------------------------
+// Write-back — Plugin-facing
+
+WriteScope ModelData::writeParam(const std::string& name) {
+    if (!ledger_) {
+        throw eckit::BadValue(
+            "ModelData::writeParam: write-back ledger not attached — "
+            "write-back must be negotiated and enabled before calling this method.",
+            Here());
+    }
+    if (!hasParameter(name)) {
+        throw eckit::BadParameter("Parameter '" + name + "' not found in model data!", Here());
+    }
+    // The in-place write scope only makes sense for atlas fields (it hands out a mutable array view) for now.
+    auto fieldPtr = std::dynamic_pointer_cast<ParameterValueTyped<atlas::Field>>(valueMap_.at(name));
+    if (!fieldPtr) {
+        throw eckit::BadValue(
+            "ModelData::writeParam: in-place write-back is only supported for atlas::Field "
+            "parameters; '" +
+                name + "' is not a field — use writeParam(name, value) instead.",
+            Here());
+    }
+    // Stage first: authorisation + single/multi-writer policy are checked here and throw cleanly on violation,
+    // so no writable buffer is resolved or exposed unless the write is legal.
+    stageWriteback(name, consumer_);
+    // getSettableField() asserts the write is authorised (ledger-enabled or Plume-owned). The scope holds the
+    // ledger (for the destructor-time abort report) and the now-staged model buffer.
+    return WriteScope{*ledger_, name, fieldPtr->getSettableField()};
 }
 
 // -------- private

--- a/src/plume/data/ModelData.cc
+++ b/src/plume/data/ModelData.cc
@@ -208,9 +208,7 @@ WriteScope ModelData::writeParam(const std::string& name) {
     // Stage first: authorisation + single/multi-writer policy are checked here and throw cleanly on violation,
     // so no writable buffer is resolved or exposed unless the write is legal.
     stageWriteback(name, consumer_);
-    // getSettableField() asserts the write is authorised (ledger-enabled or Plume-owned). The scope holds the
-    // ledger (for the destructor-time abort report) and the now-staged model buffer.
-    return WriteScope{*ledger_, name, fieldPtr->getSettableField()};
+    return WriteScope{*ledger_, name, *fieldPtr};
 }
 
 // -------- private

--- a/src/plume/data/ModelData.h
+++ b/src/plume/data/ModelData.h
@@ -223,13 +223,7 @@ public:
                 throw eckit::UserError("Parameter '" + name + "' is not owned by Plume and cannot be updated!", Here());
             }
             if constexpr (std::is_same_v<T, atlas::Field>) {
-                atlas::Field& owned = typedPtr->getSettableField();
-                if (owned.shape() != newVal.shape() || owned.datatype() != newVal.datatype()) {
-                    throw eckit::UserError(
-                        "Cannot update Atlas field '" + name + "': shape or datatype mismatch with the source field.",
-                        Here());
-                }
-                owned.array().copy(newVal.array());
+                typedPtr->writeFieldInPlace(newVal);
             }
             else {
                 typedPtr->set(newVal);
@@ -247,8 +241,9 @@ public:
      * immediately to the underlying storage — there is no intermediate buffer. If the write fails,
      * the error is reported to the ledger and the exception is re-thrown.
      *
-     * For Atlas fields, the plugin provides a new atlas::Field whose handle replaces the stored one.
-     * The model reads the new field data on acknowledgement and copies it back to its Fortran arrays.
+     * For Atlas fields using this method, the plugin provides a new atlas::Field whose underlying array is copied into
+     * the stored field. The model reads the new field data on acknowledgement and copies it back to its Fortran arrays.
+     * @todo This implies a lot of potentially expensive copies. See PLUME-75 for a structural alternative.
      *
      * @note Write-back must have been negotiated and the ledger attached by Manager before calling this.
      *
@@ -276,7 +271,12 @@ public:
 
         try {
             if (auto typedPtr = std::dynamic_pointer_cast<ParameterValueTyped<T>>(valueMap_.at(name))) {
-                typedPtr->set(value);
+                if constexpr (std::is_same_v<T, atlas::Field>) {
+                    typedPtr->writeFieldInPlace(value);
+                }
+                else {
+                    typedPtr->set(value);
+                }
                 return;
             }
             throw eckit::BadCast("ModelData::writeParam: type mismatch for parameter '" + name + "'", Here());

--- a/src/plume/data/ModelData.h
+++ b/src/plume/data/ModelData.h
@@ -279,6 +279,7 @@ public:
                 else {
                     typedPtr->set(value);
                 }
+                typedPtr->setUpdated(true);
                 return;
             }
             throw eckit::BadCast("ModelData::writeParam: type mismatch for parameter '" + name + "'", Here());
@@ -292,10 +293,10 @@ public:
     /**
      * @brief Plugin-facing in-place write-back: stage a write and return a move-only WriteScope.
      *
-     * This arity overload (no value argument) is the copy-free counterpart of writeParam(name, value): instead of
-     * copying a whole field into the model buffer, it stages the write with the ledger and hands back a WriteScope
-     * whose field() aliases the model's own buffer for in-place read-modify-write. commit() finalises; the scope's
-     * destructor aborts+reports if commit() was not called. See FieldAccess.h for the WriteScope/FieldWriter contract.
+     * Copy-free counterpart of writeParam(name, value): stages the write with the ledger and hands back a
+     * WriteScope whose field() aliases the model's own buffer for in-place read-modify-write. commit() finalises
+     * the scope and marks the parameter updated (notifying any active observers); the destructor aborts+reports
+     * if commit() was not called. See FieldAccess.h for the WriteScope/FieldWriter contract.
      *
      * @throws eckit::BadValue      if the write-back ledger is not attached.
      * @throws eckit::BadParameter  if the parameter is not found.

--- a/src/plume/data/ModelData.h
+++ b/src/plume/data/ModelData.h
@@ -28,6 +28,7 @@
 #include "atlas/util/Metadata.h"
 
 #include "plume/coupling/WriteAuthorisation.h"
+#include "plume/data/FieldAccess.h"
 #include "plume/data/ParameterCatalogue.h"
 #include "plume/data/ParameterType.h"
 #include "plume/data/ParameterValue.h"
@@ -39,6 +40,8 @@ class WriteBackLedger;  // forward declaration — ModelData holds a non-owning 
 }
 
 namespace data {
+
+class ModelDataView;  // forward declaration — filter() returns a plugin-facing view.
 
 
 // Container class for Values and pointers
@@ -62,6 +65,15 @@ private:
     coupling::WriteBackLedger* ledger_ = nullptr;
 
     /**
+     * @brief True on the instance that attached the write-back ledger (the model-facing ModelData).
+     *
+     * Set by attachWritebackLedger() — ownership is recorded exactly where it is acquired. Filtered
+     * plugin-facing views copy the ledger_ pointer (so plugins can call writeParam) but never attach, so
+     * they stay false and their base destructor must NOT detach the model's callback.
+     */
+    bool ownsLedger_ = false;
+
+    /**
      * @brief The name of the plugin this ModelData instance was filtered for.
      *
      * Set by Manager::feedPlugins() on the filtered view passed to each plugin.
@@ -69,15 +81,6 @@ private:
      * for audit logging or verbose diagnostics. Empty on the main model-facing instance.
      */
     std::string consumer_;
-
-    /**
-     * @brief Controls whether model-mutating methods (e.g. updateParam) are callable on this instance.
-     *
-     * Set to false by filter() so that plugin-facing ModelData copies cannot update owned parameters.
-     * This is a runtime guard; the stronger compile-time solution (a dedicated `ModelDataView` type
-     * using composition or private inheritance) will be implemented in PLUME-75.
-     */
-    bool modelFacing_ = true;
 
     /**
      * @brief Returns the names of all parameters in the value map.
@@ -109,16 +112,18 @@ private:
     /// Report a write failure to the ledger.
     void reportWritebackError(const std::string& name, const std::string& reason);
 
-    /// Private tag type (temporary) — used to select the plugin-facing constructor from filter(). See modelFacing_.
-    struct PluginFacingTag {};
-
-    /// Constructs a plugin-facing ModelData with modelFacing_ = false.
-    explicit ModelData(PluginFacingTag) : modelFacing_(false) {}
-
 public:
     ModelData();
 
     ~ModelData();
+
+    // Copyable but not movable. Copy is explicit (silences -Wdeprecated-copy); move is deliberately not
+    // declared because the copies that occur in practice are cheap and this avoids a moved-from ledger
+    // double-detach in the destructor. Note: the only copies in normal flow are filtered plugin-facing
+    // views (shared_ptr refcount bumps, empty strategy maps); a full model-facing copy would also clone the
+    // strategyRegistry_/strategyHelpers_ std::function maps, but that does not happen.
+    ModelData(const ModelData&)            = default;
+    ModelData& operator=(const ModelData&) = default;
 
     /**
      * @brief Creates a new value of type T, and transfer its ownership to a parameter wrapper.
@@ -199,16 +204,9 @@ public:
      *
      * @note For Atlas fields, only Plume-owned fields can be updated. Model-provided fields (provideParam) are
      *       not owned by Plume and cannot be mutated through this method.
-     * @note Not callable on plugin-facing (filtered) ModelData instances — throws at runtime. See modelFacing_.
      */
     template <typename T>
     void updateParam(std::string name, T newVal) {
-        if (!modelFacing_) {
-            throw eckit::BadValue(
-                "ModelData::updateParam is not callable on a plugin-facing ModelData. "
-                "Use writeParam() to write back values during a run cycle.",
-                Here());
-        }
         if (!hasParameter(name)) {
             throw eckit::BadParameter("Parameter '" + name + "' not found in model data!", Here());
         }
@@ -243,20 +241,24 @@ public:
      *
      * For Atlas fields using this method, the plugin provides a new atlas::Field whose underlying array is copied into
      * the stored field. The model reads the new field data on acknowledgement and copies it back to its Fortran arrays.
-     * @todo This implies a lot of potentially expensive copies. See PLUME-75 for a structural alternative.
+     * This implies a lot of potentially expensive copies, prefer the below scoped version.
      *
      * @note Write-back must have been negotiated and the ledger attached by Manager before calling this.
-     *
-     * @warning Plugins must use this method and not mutate fields obtained via getParam — doing so bypasses
-     *          the ledger and the write-back lifecycle entirely. PLUME-75 tracks a structural fix to prevent this.
      *
      * @throws eckit::BadValue      if the write-back ledger is not attached.
      * @throws eckit::BadParameter  if the parameter is not found.
      * @throws eckit::BadValue      (from ledger) if the plugin is not authorised or policy is violated.
      * @throws eckit::BadCast       if the value type does not match the stored parameter type.
      */
-    template <typename T>
+    template <typename T, std::enable_if_t<!std::is_invocable_v<T&, FieldWriter&>, int> = 0>
     void writeParam(const std::string& name, const T& value) {
+        // FieldView is a read-only handle and FieldWriter is a scope-bound in-place handle — neither is a value that
+        // can be written back. Reject them at compile time with a pointer to the right path instead of failing at
+        // runtime with a type-mismatch cast.
+        static_assert(!std::is_same_v<T, FieldView> && !std::is_same_v<T, FieldWriter>,
+                      "writeParam(name, value) cannot take a FieldView/FieldWriter: they are access handles, not "
+                      "values. Call fieldView.clone() to get a mutable atlas::Field to write back, or use the in-place "
+                      "writeParam(name, body) form to modify the model buffer directly.");
         if (!ledger_) {
             throw eckit::BadValue(
                 "ModelData::writeParam: write-back ledger not attached — "
@@ -288,16 +290,65 @@ public:
     }
 
     /**
+     * @brief Plugin-facing in-place write-back: stage a write and return a move-only WriteScope.
+     *
+     * This arity overload (no value argument) is the copy-free counterpart of writeParam(name, value): instead of
+     * copying a whole field into the model buffer, it stages the write with the ledger and hands back a WriteScope
+     * whose field() aliases the model's own buffer for in-place read-modify-write. commit() finalises; the scope's
+     * destructor aborts+reports if commit() was not called. See FieldAccess.h for the WriteScope/FieldWriter contract.
+     *
+     * @throws eckit::BadValue      if the write-back ledger is not attached.
+     * @throws eckit::BadParameter  if the parameter is not found.
+     * @throws eckit::BadValue      if the parameter is not an atlas::Field (use writeParam(name, value) instead).
+     * @throws eckit::BadValue      (from ledger, during staging) if the plugin is not authorised or policy is violated.
+     */
+    WriteScope writeParam(const std::string& name);
+
+    /**
+     * @brief Plugin-facing in-place write-back, context-manager style: stage, run a body against the model buffer,
+     *        and commit — the everyday plugin-author-facing form of the copy-free path.
+     *
+     * This callable overload owns a WriteScope internally so the author supplies only the field math and never
+     * touches staging or commit(). It runs @p body with a FieldWriter aliasing the model's own buffer, then commits;
+     * if @p body throws, the WriteScope destructor aborts and reports the failure to the ledger (so a partial write
+     * is not silently kept). The body typically builds a mutable atlas view over the FieldWriter and mutates in place:
+     *
+     * @code
+     *   data.writeParam("swh", [](plume::data::FieldWriter& f) {
+     *       auto v = atlas::array::make_view<double, 2>(f);   // mutable view over the model buffer
+     *       for (...) v(i, j) *= 1.05;                        // in-place read-modify-write
+     *   });
+     * @endcode
+     *
+     * The value and callable overloads are mutually exclusive via std::is_invocable_v<F&, FieldWriter&>, so a field or
+     * scalar selects writeParam(name, value) while a callable selects this one. Both `[](FieldWriter&){...}` and, by
+     * the FieldWriter → atlas::array::Array& conversion, `[](atlas::array::Array&){...}` and generic `[](auto& f){...}`
+     * bodies resolve here.
+     *
+     * @note C++-only utility. This form takes a C++ callable and hands it a FieldWriter, so it is available only to
+     *       C++ plugins holding a ModelData(View). Fortran/C plugins drive the copy-free write-back through the
+     *       WriteScope begin→mutate→commit C API instead.
+     *
+     * @throws eckit::BadValue/BadParameter as writeParam(name), plus anything @p body throws (after the abort report).
+     */
+    template <typename F, std::enable_if_t<std::is_invocable_v<F&, FieldWriter&>, int> = 0>
+    void writeParam(const std::string& name, F&& body) {
+        WriteScope scope   = writeParam(name);
+        FieldWriter writer = scope.field();
+        body(writer);
+        scope.commit();
+    }
+
+    /**
      * @brief Accesses a value of a parameter. Intended for data users to "update" their local view of the model data.
      *
      * @note This interface can be used for source & derived params if the full name is known.
-     * @warning For atlas::Field parameters, the returned handle shares the underlying field data with the
-     *          stored parameter. Mutating the field through this handle bypasses the write-back ledger
-     *          entirely. Plugins with write-back authorisation must use writeParam() instead. PLUME-75 will
-     *          implement a structural fix to prevent plugins from mutating fields obtained via getParam().
+     * 
+     * @note For atlas::Field parameters, the returned handle is one of the FieldAccess types to avoid passing mutable
+     *       arrays to unauthorised plugins, and prevent write-back ledger bypass.
      */
     template <typename T>
-    T getParam(std::string name) const {
+    T getParam(const std::string& name) const {
         if (!hasParameter(name)) {
             throw eckit::BadParameter("Parameter '" + name + "' not found in model data!", Here());
         }
@@ -318,11 +369,11 @@ public:
         return getParam<T>(entryName);
     }
 
-    // Return a subset of the ModelData, optionally tagged with the consumer plugin name.
-    ModelData filter(std::set<std::string> params, const std::string& consumer = "") const;
+    /// Returns a subset of the ModelData as a plugin-facing view, optionally tagged with the consumer plugin name.
+    ModelDataView filter(std::set<std::string> params, const std::string& consumer = "") const;
 
-    // Return a subset of the ModelData, optionally tagged with the consumer plugin name.
-    ModelData filter(ParameterCatalogue params, const std::string& consumer = "") const;
+    /// Returns a subset of the ModelData as a plugin-facing view, optionally tagged with the consumer plugin name.
+    ModelDataView filter(ParameterCatalogue params, const std::string& consumer = "") const;
 
     // check if a parameter is in the data
     bool hasParameter(const std::string& name) const;

--- a/src/plume/data/ModelDataView.h
+++ b/src/plume/data/ModelDataView.h
@@ -1,0 +1,96 @@
+/*
+ * (C) Copyright 2023- ECMWF.
+ *
+ * This software is licensed under the terms of the Apache Licence Version 2.0
+ * which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * In applying this licence, ECMWF does not waive the privileges and immunities
+ * granted to it by virtue of its status as an intergovernmental organisation nor
+ * does it submit to any jurisdiction.
+ */
+#pragma once
+
+#include <type_traits>
+
+#include "plume/data/FieldAccess.h"
+#include "plume/data/ModelData.h"
+
+namespace plume {
+namespace data {
+
+/**
+ * @brief Plugin-facing, read/write-restricted view over a ModelData.
+ *
+ * ModelDataView is the type handed to plugins (via PluginCore::modelData()). It exposes only the plugin-legal surface
+ * of ModelData — reading parameters (getParam), writing model values back through the authorised ledger (writeParam),
+ * and querying availability/updated state — while making the model-only mutation entry points (updateParam,
+ * provideParam, createParam, ...) and the Manager-facing lifecycle (filter, ledger attach/enroll, acknowledge/pending,
+ * ...) inaccessible.
+ *
+ * Enforcement is structural rather than runtime: ModelDataView privately inherits ModelData, so a plugin cannot slice
+ * or cast a view back to a ModelData& to reach the hidden methods — any such attempt is a compile error.
+ * Only the members re-published below via `using` are reachable.
+ *
+ * @note The view borrows nothing: it owns the (filtered) ModelData moved into it, so its lifetime is
+ *       self-contained and it carries the write-back ledger pointer and consumer tag set by filter().
+ *
+ * @note (PLUME-82) A ModelDataView *shares ownership* of the model's parameters: filter() copies each
+ *       parameter's std::shared_ptr into the view (see ModelData::filter), so a plugin's view and the
+ *       model-facing ModelData co-own the same atlas::Field handles. This paradigm is under review: it
+ *       couples plugin-view lifetime to model-parameter (and thus atlas::Field) lifetime, which caused a
+ *       teardown heap corruption when a view retained in the process-static PluginRegistry outlived atlas'
+ *       thread-local allocator and destroyed its shared fields at program exit. The current mitigation is
+ *       PluginHandler::teardown() → PluginCore::releaseData(), which drops the view during finalise() while
+ *       atlas is still alive. PLUME-82 tracks making views non-owning observers of model parameters instead,
+ *       which would remove the need for that explicit release.
+ */
+class ModelDataView : private ModelData {
+public:
+    /// Wraps a (typically filtered) ModelData, taking ownership of it.
+    explicit ModelDataView(ModelData data) : ModelData(std::move(data)) {}
+
+    // --- Plugin-legal surface (re-published from the private base) -----------
+
+    // Read parameter values. Scalars are returned by value unchanged; an atlas::Field is returned as a read-only
+    // FieldView (never a mutable atlas::Field handle), so a plugin holding only a view cannot copy out a mutable
+    // handle and bypass the write-back ledger. The call syntax is unchanged: getParam<atlas::Field>(name) still
+    // reads naturally and make_view(...) over the result yields a const view. See ModelData::getParam for the
+    // derived-name (level/levtype) semantics of the second overload.
+    template <typename T>
+    std::conditional_t<std::is_same_v<T, atlas::Field>, FieldView, T> getParam(const std::string& name) const {
+        if constexpr (std::is_same_v<T, atlas::Field>) {
+            return FieldView(ModelData::getParam<atlas::Field>(name));
+        }
+        else {
+            return ModelData::getParam<T>(name);
+        }
+    }
+
+    template <typename T>
+    std::conditional_t<std::is_same_v<T, atlas::Field>, FieldView, T> getParam(
+        const std::string& name, const std::string& level, const std::string& levtype = "hl") const {
+        if constexpr (std::is_same_v<T, atlas::Field>) {
+            return FieldView(ModelData::getParam<atlas::Field>(name, level, levtype));
+        }
+        else {
+            return ModelData::getParam<T>(name, level, levtype);
+        }
+    }
+
+    // Write model values back within the authorised write-back protocol.
+    using ModelData::writeParam;
+
+    // Query updated state and availability.
+    using ModelData::hasParameter;
+    using ModelData::isUpdated;
+    using ModelData::listAvailableParameters;
+
+    // Diagnostics.
+    using ModelData::print;
+
+    // Identity of the plugin this view was filtered for (read-only).
+    using ModelData::consumer;
+};
+
+}  // namespace data
+}  // namespace plume

--- a/src/plume/data/ParameterValue.h
+++ b/src/plume/data/ParameterValue.h
@@ -18,6 +18,7 @@
 
 #include "eckit/exception/Exceptions.h"
 
+#include "atlas/array/Array.h"
 #include "atlas/field/Field.h"
 
 #include "plume/coupling/WriteBackKey.h"
@@ -129,10 +130,12 @@ public:
     const T& get() const { return *valuePtr_; }
 
     /**
-     * @brief Sets the parameter value.
+     * @brief Replaces the stored value or handle.
      *
-     * For Atlas fields this replaces the stored handle, which lets update strategies reshape or reinitialise an
-     * owned field. Model-facing in-place mutation that preserves the handle identity is done via updateParam.
+     * For Atlas fields this rebinds the stored handle to @p value, which lets update strategies reshape or
+     * reinitialise an owned field (e.g. from 3D to 2D). It does not write into the previously referenced data
+     * buffer. In-place mutation that preserves the handle identity (and hence the shared model buffer for
+     * provided fields) is done via writeFieldInPlace().
      *
      * Allowed when owning the value (normal case) or when write-back is active
      * (non-owning parameter authorised by WritebackLedger via isWritable()).
@@ -143,13 +146,40 @@ public:
     }
 
     /**
-     * @brief Returns a mutable reference to the stored Atlas field.
+     * @brief Copies the data of an Atlas field @p value into the existing field buffer, preserving handle identity.
      *
-     * Allowed when owning the field or when write-back is active.
+     * Unlike set(), this does not rebind the stored handle: it copies element data into the already-referenced
+     * field implementation, so the update is visible through every handle sharing that implementation — in
+     * particular the model's own handle for a provided field. This is the write path used by model-facing updates
+     * (updateParam) and plugin write-back (writeParam); it deliberately does not use getSettableField(), which is
+     * reserved for update strategies.
+     *
+     * Allowed when owning the field (normal case) or when write-back is active
+     * (non-owning parameter authorised by WritebackLedger via isWritable()).
+     *
+     * @throws eckit::UserError if @p value has a shape or datatype that differs from the stored field.
+     */
+    template <typename U = T, typename = std::enable_if_t<std::is_base_of_v<atlas::Field, U>>>
+    void writeFieldInPlace(const T& value) {
+        ASSERT(ownsValue_ || isWritable());
+        if (valuePtr_->shape() != value.shape() || valuePtr_->datatype() != value.datatype()) {
+            throw eckit::UserError("Cannot write Atlas field '" + valuePtr_->name() +
+                                       "': shape or datatype mismatch with the source field.",
+                                   Here());
+        }
+        valuePtr_->array().copy(value.array());
+    }
+
+    /**
+     * @brief Returns a mutable reference to the stored Atlas field for in-place mutation.
+     *
+     * @warning Plume-internal. Intended only for update strategies mutating Plume-owned fields. Plugin write-back
+     *          and model-facing updates must go through writeFieldInPlace(), which keeps the write-back guarantees
+     *          and the model-owned/Plume-owned distinction intact.
      */
     template <typename U = T, typename = std::enable_if_t<std::is_base_of_v<atlas::Field, U>>>
     T& getSettableField() {
-        ASSERT(ownsValue_ || isWritable());
+        ASSERT(ownsValue_);
         return *valuePtr_;
     }
 };

--- a/src/plume/data/ParameterValue.h
+++ b/src/plume/data/ParameterValue.h
@@ -96,7 +96,8 @@ public:
      * exception: `atlas::Field` is a reference-counted handle around model-owned data, so a copy of the handle is
      * kept as backing storage to keep the field accessible for the session. In both cases the parameter stays
      * non-owning (`ownsValue_ == false`): Plume does not own the underlying data, so `set()`/`getSettableField()`
-     * remain disallowed and `updateParam` cannot mutate it.
+     * are disallowed unless write-back has been authorised for it by the ledger (`isWritable()`), and `updateParam`
+     * (model-facing, owned-only) can never mutate it.
      *
      * @question: do we need special cases for char, char* ? There is currently no support in the C API.
      */
@@ -151,8 +152,8 @@ public:
      * Unlike set(), this does not rebind the stored handle: it copies element data into the already-referenced
      * field implementation, so the update is visible through every handle sharing that implementation — in
      * particular the model's own handle for a provided field. This is the write path used by model-facing updates
-     * (updateParam) and plugin write-back (writeParam); it deliberately does not use getSettableField(), which is
-     * reserved for update strategies.
+     * (updateParam) and the value-based plugin write-back (writeParam(name, value)); it copies rather than handing
+     * out the buffer, so unlike getSettableField() it also validates shape/datatype against the stored field.
      *
      * Allowed when owning the field (normal case) or when write-back is active
      * (non-owning parameter authorised by WritebackLedger via isWritable()).
@@ -171,15 +172,19 @@ public:
     }
 
     /**
-     * @brief Returns a mutable reference to the stored Atlas field for in-place mutation.
+     * @brief Returns a mutable reference to the stored Atlas field for authorised in-place mutation.
      *
-     * @warning Plume-internal. Intended only for update strategies mutating Plume-owned fields. Plugin write-back
-     *          and model-facing updates must go through writeFieldInPlace(), which keeps the write-back guarantees
-     *          and the model-owned/Plume-owned distinction intact.
+     * Hands back the field buffer itself (handle identity preserved) so the caller can mutate the model's data in
+     * place with no scratch allocation. Two callers use it: update strategies mutating Plume-owned fields, and the
+     * in-place plugin write-back path (WriteScope/FieldWriter) once the write is authorised by the ledger. The guard
+     * mirrors writeFieldInPlace().
+     *
+     * @warning Plume-internal. The reference aliases the model's own buffer; only hand it out behind the write-back
+     *          protocol (an authorised, staged WriteScope) or a strategy on a Plume-owned field.
      */
     template <typename U = T, typename = std::enable_if_t<std::is_base_of_v<atlas::Field, U>>>
     T& getSettableField() {
-        ASSERT(ownsValue_);
+        ASSERT(ownsValue_ || isWritable());
         return *valuePtr_;
     }
 };

--- a/tests/api/CMakeLists.txt
+++ b/tests/api/CMakeLists.txt
@@ -126,3 +126,24 @@ add_fctest( TARGET   plume_test_writeback_fapi
             LIBS
               plume_f
 )
+
+
+# ----------------------------------------------------------------------------------------------------------------------
+# Compile-time enforcement: a Fortran plugin holds a plume_data_view and MUST NOT be able to call a model-only mutator.
+# The target is EXCLUDE_FROM_ALL (so the normal build stays green) and the test below drives its compilation and asserts
+# it FAILS (WILL_FAIL). If enforcement regresses, the target compiles and the test fails.
+# ----------------------------------------------------------------------------------------------------------------------
+ecbuild_add_executable( TARGET       plume_should_not_compile_fapi
+                        SOURCES      should_not_compile_fapi.F90
+                        LIBS         plume_f
+                        NOINSTALL )
+set_target_properties( plume_should_not_compile_fapi
+                       PROPERTIES EXCLUDE_FROM_ALL TRUE EXCLUDE_FROM_DEFAULT_BUILD TRUE )
+
+ecbuild_add_test( TARGET          plume_test_fapi_view_enforcement
+                  COMMAND         ${CMAKE_COMMAND}
+                  ARGS            --build ${CMAKE_BINARY_DIR}
+                                  --target plume_should_not_compile_fapi
+                                  --config $<CONFIG>
+                  LABELS          fortran
+                  TEST_PROPERTIES WILL_FAIL TRUE )

--- a/tests/api/plugin_test_fapi.F90
+++ b/tests/api/plugin_test_fapi.F90
@@ -13,13 +13,13 @@ use iso_c_binding, only : c_ptr, c_null_char, c_loc
 ! wrapper of model data
 use fckit_configuration_module, only : fckit_configuration
 use plume_module, only : plume_check
-use plume_data_module, only : plume_data
+use plume_data_module, only : plume_data_view
 
 implicit none
 private
 
 ! Model data available for the plugincore
-type(plume_data), public :: fapi_data
+type(plume_data_view), public :: fapi_data
 type(fckit_configuration), public :: fapi_configuration
 
 contains

--- a/tests/api/plugin_writeback_api.cc
+++ b/tests/api/plugin_writeback_api.cc
@@ -50,7 +50,8 @@ void WriteBackTestAPICore::run() {
 
     // Build a brand-new field (distinct implementation from the model's) carrying the updated values, then write
     // it back. write-back must copy the data into the model's own buffer in place, not rebind the handle.
-    const atlas::Field current = modelData().getParam<atlas::Field>("W_FIELD");
+    // getParam yields a read-only FieldView on the plugin path; we only read its datatype()/shape() metadata here.
+    const auto current = modelData().getParam<atlas::Field>("W_FIELD");
     atlas::Field update("W_FIELD", current.datatype(), current.shape());
     auto view = atlas::array::make_view<int, 1>(update);
     for (int i = 0; i < static_cast<int>(view.shape(0)); ++i) {

--- a/tests/api/plugin_writeback_api.cc
+++ b/tests/api/plugin_writeback_api.cc
@@ -11,6 +11,12 @@
 #include "plugin_writeback_api.h"
 #include "plume/Protocol.h"
 
+#include "atlas/array/ArrayShape.h"
+#include "atlas/array/ArrayView.h"
+#include "atlas/array/DataType.h"
+#include "atlas/array/MakeView.h"
+#include "atlas/field/Field.h"
+
 namespace plume_writeback_test_api {
 
 REGISTER_LIBRARY(WriteBackTestAPI)
@@ -28,6 +34,7 @@ plume::Protocol WriteBackTestAPI::negotiate() {
     protocol.requireWritable<bool>("W_BOOL");
     protocol.requireWritable<float>("W_FLOAT");
     protocol.requireWritable<double>("W_DOUBLE");
+    protocol.requireWritable<atlas::Field>("W_FIELD");
     return protocol;
 }
 
@@ -40,6 +47,16 @@ void WriteBackTestAPICore::run() {
     modelData().writeParam<bool>("W_BOOL", true);
     modelData().writeParam<float>("W_FLOAT", 3.14f);
     modelData().writeParam<double>("W_DOUBLE", 2.718);
+
+    // Build a brand-new field (distinct implementation from the model's) carrying the updated values, then write
+    // it back. write-back must copy the data into the model's own buffer in place, not rebind the handle.
+    const atlas::Field current = modelData().getParam<atlas::Field>("W_FIELD");
+    atlas::Field update("W_FIELD", current.datatype(), current.shape());
+    auto view = atlas::array::make_view<int, 1>(update);
+    for (int i = 0; i < static_cast<int>(view.shape(0)); ++i) {
+        view(i) = (i + 1) * 100;
+    }
+    modelData().writeParam<atlas::Field>("W_FIELD", update);
 }
 
 }  // namespace plume_writeback_test_api

--- a/tests/api/plugin_writeback_fapi.F90
+++ b/tests/api/plugin_writeback_fapi.F90
@@ -29,8 +29,24 @@ end subroutine
 subroutine plugincore_run_writeback_fapi() &
 bind(C, name="plugincore_run_writeback_fapi")
     use iso_c_binding, only: c_double, c_int
+    use atlas_module, only: atlas_Field, atlas_integer
+    type(atlas_Field) :: current, update
+    integer(c_int), pointer :: cdata(:), udata(:)
+    integer :: i, n
     call plume_check(writeback_fapi_data%write_int("FORT_W_INT"//c_null_char, 99_c_int))
     call plume_check(writeback_fapi_data%write_double("FORT_W_DOUBLE"//c_null_char, real(1.23d0, kind=c_double)))
+
+    ! Build a distinct field carrying updated values (sized from the provided field) and write it back. The
+    ! write-back must copy the data into the model's own buffer in place rather than rebind the handle.
+    call plume_check(writeback_fapi_data%get_shared_atlas_field("FORT_W_FIELD", current))
+    call current%data(cdata)
+    n = size(cdata)
+    update = atlas_Field("FORT_W_FIELD", atlas_integer(), (/n/))
+    call update%data(udata)
+    do i = 1, n
+        udata(i) = i * 100_c_int
+    end do
+    call plume_check(writeback_fapi_data%write_atlas_field("FORT_W_FIELD", update))
 end subroutine
 
 subroutine plugincore_teardown_writeback_fapi() &

--- a/tests/api/plugin_writeback_fapi.F90
+++ b/tests/api/plugin_writeback_fapi.F90
@@ -10,12 +10,12 @@ module plugin_writeback_fapi_module
 
 use iso_c_binding, only : c_ptr, c_null_char
 use plume_module, only : plume_check
-use plume_data_module, only : plume_data
+use plume_data_module, only : plume_data_view
 
 implicit none
 private
 
-type(plume_data), public :: writeback_fapi_data
+type(plume_data_view), public :: writeback_fapi_data
 
 contains
 
@@ -30,6 +30,7 @@ subroutine plugincore_run_writeback_fapi() &
 bind(C, name="plugincore_run_writeback_fapi")
     use iso_c_binding, only: c_double, c_int
     use atlas_module, only: atlas_Field, atlas_integer
+    use plume_data_module, only: plume_write_scope
     type(atlas_Field) :: current, update
     integer(c_int), pointer :: cdata(:), udata(:)
     integer :: i, n
@@ -46,7 +47,43 @@ bind(C, name="plugincore_run_writeback_fapi")
     do i = 1, n
         udata(i) = i * 100_c_int
     end do
-    call plume_check(writeback_fapi_data%write_atlas_field("FORT_W_FIELD", update))
+    call plume_check(writeback_fapi_data%write_atlas_field_copy("FORT_W_FIELD", update))
+
+    ! Copy-free, in-place write-back via the RAII WriteScope: stage the scope, alias the model's own buffer with
+    ! view(), read-modify-write in place, and let the auto-commit fire when the block (and thus the scope) ends.
+    block
+        type(plume_write_scope)  :: scope
+        type(atlas_Field)        :: staged
+        integer(c_int), pointer  :: sdata(:)
+        integer                  :: j
+        integer(c_int)           :: scope_err
+        call writeback_fapi_data%write_atlas_field_scope("FORT_W_SCOPE_FIELD", scope, scope_err)
+        call plume_check(scope_err)
+        call scope%view(staged)
+        call staged%data(sdata)
+        do j = 1, size(sdata)
+            sdata(j) = sdata(j) + 1000_c_int  ! in-place read-modify-write on the model buffer
+        end do
+    end block  ! scope finalised here → auto-commit of the in-place write-back
+
+    ! Same copy-free path but with an EXPLICIT commit(): the value must land, and the block-exit finaliser must be a
+    ! safe no-op afterwards (the c_associated guard neutralises the scope so it is not committed/freed a second time).
+    block
+        type(plume_write_scope)  :: scope2
+        type(atlas_Field)        :: staged2
+        integer(c_int), pointer  :: sdata2(:)
+        integer                  :: k
+        integer(c_int)           :: scope2_err, commit_err
+        call writeback_fapi_data%write_atlas_field_scope("FORT_W_SCOPE_FIELD2", scope2, scope2_err)
+        call plume_check(scope2_err)
+        call scope2%view(staged2)
+        call staged2%data(sdata2)
+        do k = 1, size(sdata2)
+            sdata2(k) = sdata2(k) + 500_c_int
+        end do
+        commit_err = scope2%commit()  ! explicit commit
+        call plume_check(commit_err)
+    end block  ! finaliser runs but the guard makes the second commit a no-op (no double-commit/double-free)
 end subroutine
 
 subroutine plugincore_teardown_writeback_fapi() &

--- a/tests/api/should_not_compile_fapi.F90
+++ b/tests/api/should_not_compile_fapi.F90
@@ -1,0 +1,30 @@
+! (C) Copyright 2023- ECMWF.
+!
+! This software is licensed under the terms of the Apache Licence Version 2.0
+! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+!
+! In applying this licence, ECMWF does not waive the privileges and immunities
+! granted to it by virtue of its status as an intergovernmental organisation nor
+! does it submit to any jurisdiction.
+
+! Compile-time enforcement fixture for the Fortran plugin/model data-access contract (PLUME-75).
+!
+! plume_data_view (plugin-facing) binds ONLY the plugin-legal procedures; plume_data (model-facing)
+! extends it with the model-only mutators (update_*/provide_*/create_*/...). A Fortran plugin therefore
+! holds a plume_data_view and MUST NOT be able to call a mutator.
+!
+! This program deliberately calls a model-only binding (update_int) on a plume_data_view. It MUST FAIL
+! to compile. The build target is EXCLUDE_FROM_ALL and the accompanying CTest expects the build to fail
+! (WILL_FAIL). If enforcement ever regresses, this program compiles and the test then fails.
+program should_not_compile_fapi
+    use iso_c_binding, only : c_int, c_null_char
+    use plume_data_module, only : plume_data_view
+    implicit none
+
+    type(plume_data_view) :: view
+    integer :: err
+
+    ! update_int is bound on plume_data, NOT on plume_data_view — this line must not compile.
+    err = view%update_int("x"//c_null_char, 1_c_int)
+
+end program should_not_compile_fapi

--- a/tests/api/test_writeback_api.cc
+++ b/tests/api/test_writeback_api.cc
@@ -15,6 +15,12 @@
 #include "plume/api/plume.h"
 #include "test_api_utils.h"
 
+#include "atlas/array/ArrayShape.h"
+#include "atlas/array/ArrayView.h"
+#include "atlas/array/DataType.h"
+#include "atlas/array/MakeView.h"
+#include "atlas/field/Field.h"
+
 using namespace eckit::testing;
 
 namespace plume::test {
@@ -35,6 +41,8 @@ CASE("test_writeback_api") {
         plume_protocol_offer_float_writable(protocol_handle, "W_FLOAT", "always", "writable float"));
     EXPECT_PLUME_CODE_SUCCESS(
         plume_protocol_offer_double_writable(protocol_handle, "W_DOUBLE", "always", "writable double"));
+    EXPECT_PLUME_CODE_SUCCESS(
+        plume_protocol_offer_atlas_field_writable(protocol_handle, "W_FIELD", "always", "writable atlas field"));
 
     std::string mgr_conf_str = R"YAML(
       write-back-policy: single-writer
@@ -55,6 +63,9 @@ CASE("test_writeback_api") {
               - name: W_DOUBLE
                 type: DOUBLE
                 writable: true
+              - name: W_FIELD
+                type: ATLAS_FIELD
+                writable: true
           core-config: {}
     )YAML";
 
@@ -74,6 +85,18 @@ CASE("test_writeback_api") {
     EXPECT_PLUME_CODE_SUCCESS(plume_data_provide_float(data_handle, "W_FLOAT", &w_float));
     EXPECT_PLUME_CODE_SUCCESS(plume_data_create_double(data_handle, "W_DOUBLE", 0.0));  // Plume-owned
 
+    // Provided (model-owned) atlas field: storage stays with the model, shared with Plume via a handle. The
+    // write-back must land in this buffer in place, observable through this very field without a read-back.
+    atlas::Field w_field("W_FIELD", atlas::array::make_datatype<int>(), atlas::array::make_shape(3));
+    {
+        auto seed = atlas::array::make_view<int, 1>(w_field);
+        seed(0) = 1;
+        seed(1) = 2;
+        seed(2) = 3;
+    }
+    const atlas::Field::Implementation* w_field_impl = w_field.get();
+    EXPECT_PLUME_CODE_SUCCESS(plume_data_provide_atlas_field_shared(data_handle, "W_FIELD", w_field.get()));
+
     EXPECT_PLUME_CODE_SUCCESS(plume_manager_feed_plugins(mgr_handle, data_handle));
 
     // Run the plugin — it writes W_INT=42, W_BOOL=true, W_FLOAT=3.14f, W_DOUBLE=2.718
@@ -89,6 +112,16 @@ CASE("test_writeback_api") {
     EXPECT_PLUME_CODE_SUCCESS(plume_data_get_double(data_handle, "W_DOUBLE", &w_double_check));
     EXPECT(eckit::types::is_approximately_equal(w_double_check, 2.718));
 
+    // Verify the provided atlas field was written in place: the model's own handle sees the new values and the
+    // underlying implementation was not swapped for the plugin's field.
+    EXPECT(w_field.get() == w_field_impl);
+    {
+        auto check = atlas::array::make_view<int, 1>(w_field);
+        EXPECT_EQUAL(check(0), 100);
+        EXPECT_EQUAL(check(1), 200);
+        EXPECT_EQUAL(check(2), 300);
+    }
+
     // Verify pending write-backs
     char* pending_csv = nullptr;
     EXPECT_PLUME_CODE_SUCCESS(plume_data_pending_writebacks(data_handle, &pending_csv));
@@ -99,12 +132,14 @@ CASE("test_writeback_api") {
     EXPECT(pending.find("W_BOOL") != std::string::npos);
     EXPECT(pending.find("W_FLOAT") != std::string::npos);
     EXPECT(pending.find("W_DOUBLE") != std::string::npos);
+    EXPECT(pending.find("W_FIELD") != std::string::npos);
 
     // Acknowledge each write-back
     EXPECT_PLUME_CODE_SUCCESS(plume_data_acknowledge_writeback(data_handle, "W_INT"));
     EXPECT_PLUME_CODE_SUCCESS(plume_data_acknowledge_writeback(data_handle, "W_BOOL"));
     EXPECT_PLUME_CODE_SUCCESS(plume_data_acknowledge_writeback(data_handle, "W_FLOAT"));
     EXPECT_PLUME_CODE_SUCCESS(plume_data_acknowledge_writeback(data_handle, "W_DOUBLE"));
+    EXPECT_PLUME_CODE_SUCCESS(plume_data_acknowledge_writeback(data_handle, "W_FIELD"));
 
     // Verify no more pending write-backs after acknowledgement
     EXPECT_PLUME_CODE_SUCCESS(plume_data_pending_writebacks(data_handle, &pending_csv));
@@ -115,6 +150,7 @@ CASE("test_writeback_api") {
     EXPECT(pending.find("W_BOOL") == std::string::npos);
     EXPECT(pending.find("W_FLOAT") == std::string::npos);
     EXPECT(pending.find("W_DOUBLE") == std::string::npos);
+    EXPECT(pending.find("W_FIELD") == std::string::npos);
 
     EXPECT_PLUME_CODE_SUCCESS(plume_manager_teardown(mgr_handle));
     EXPECT_PLUME_CODE_SUCCESS(plume_manager_delete_handle(mgr_handle));

--- a/tests/api/test_writeback_api.cc
+++ b/tests/api/test_writeback_api.cc
@@ -90,9 +90,9 @@ CASE("test_writeback_api") {
     atlas::Field w_field("W_FIELD", atlas::array::make_datatype<int>(), atlas::array::make_shape(3));
     {
         auto seed = atlas::array::make_view<int, 1>(w_field);
-        seed(0) = 1;
-        seed(1) = 2;
-        seed(2) = 3;
+        seed(0)   = 1;
+        seed(1)   = 2;
+        seed(2)   = 3;
     }
     const atlas::Field::Implementation* w_field_impl = w_field.get();
     EXPECT_PLUME_CODE_SUCCESS(plume_data_provide_atlas_field_shared(data_handle, "W_FIELD", w_field.get()));
@@ -114,7 +114,7 @@ CASE("test_writeback_api") {
 
     // Verify the provided atlas field was written in place: the model's own handle sees the new values and the
     // underlying implementation was not swapped for the plugin's field.
-    EXPECT(w_field.get() == w_field_impl);
+    EXPECT_EQUAL(w_field.get(), w_field_impl);
     {
         auto check = atlas::array::make_view<int, 1>(w_field);
         EXPECT_EQUAL(check(0), 100);
@@ -128,11 +128,11 @@ CASE("test_writeback_api") {
     std::string pending(pending_csv);
     plume_free_string(pending_csv);
 
-    EXPECT(pending.find("W_INT") != std::string::npos);
-    EXPECT(pending.find("W_BOOL") != std::string::npos);
-    EXPECT(pending.find("W_FLOAT") != std::string::npos);
-    EXPECT(pending.find("W_DOUBLE") != std::string::npos);
-    EXPECT(pending.find("W_FIELD") != std::string::npos);
+    EXPECT_NOT_EQUAL(pending.find("W_INT"), std::string::npos);
+    EXPECT_NOT_EQUAL(pending.find("W_BOOL"), std::string::npos);
+    EXPECT_NOT_EQUAL(pending.find("W_FLOAT"), std::string::npos);
+    EXPECT_NOT_EQUAL(pending.find("W_DOUBLE"), std::string::npos);
+    EXPECT_NOT_EQUAL(pending.find("W_FIELD"), std::string::npos);
 
     // Acknowledge each write-back
     EXPECT_PLUME_CODE_SUCCESS(plume_data_acknowledge_writeback(data_handle, "W_INT"));
@@ -146,16 +146,42 @@ CASE("test_writeback_api") {
     pending = pending_csv;
     plume_free_string(pending_csv);
 
-    EXPECT(pending.find("W_INT") == std::string::npos);
-    EXPECT(pending.find("W_BOOL") == std::string::npos);
-    EXPECT(pending.find("W_FLOAT") == std::string::npos);
-    EXPECT(pending.find("W_DOUBLE") == std::string::npos);
-    EXPECT(pending.find("W_FIELD") == std::string::npos);
+    EXPECT_EQUAL(pending.find("W_INT"), std::string::npos);
+    EXPECT_EQUAL(pending.find("W_BOOL"), std::string::npos);
+    EXPECT_EQUAL(pending.find("W_FLOAT"), std::string::npos);
+    EXPECT_EQUAL(pending.find("W_DOUBLE"), std::string::npos);
+    EXPECT_EQUAL(pending.find("W_FIELD"), std::string::npos);
 
     EXPECT_PLUME_CODE_SUCCESS(plume_manager_teardown(mgr_handle));
     EXPECT_PLUME_CODE_SUCCESS(plume_manager_delete_handle(mgr_handle));
     EXPECT_PLUME_CODE_SUCCESS(plume_data_delete_handle(data_handle));
     EXPECT_PLUME_CODE_SUCCESS(plume_protocol_delete_handle(protocol_handle));
+    EXPECT_PLUME_CODE_SUCCESS(plume_finalise());
+}
+
+CASE("test_writeback_scope_api_error_codes") {
+    // The C boundary must translate scope-begin failures into non-zero return codes rather than crashing the caller.
+    // The underlying C++ throws (unauthorised / non-field / no-ledger) are exercised by the core tests; here we only
+    // assert that plume_data_write_scope_begin surfaces them as error codes across the C API.
+    plume_data_handle_t* data_handle;
+
+    EXPECT_PLUME_CODE_SUCCESS(plume_initialise(eckit::Main::instance().argc(), eckit::Main::instance().argv()));
+    EXPECT_PLUME_CODE_SUCCESS(plume_data_create_handle_t(&data_handle));
+
+    // Provide a field but attach NO write-back ledger: opening a write scope must fail cleanly with a non-zero code.
+    atlas::Field w_field("W_FIELD", atlas::array::make_datatype<int>(), atlas::array::make_shape(3));
+    EXPECT_PLUME_CODE_SUCCESS(plume_data_provide_atlas_field_shared(data_handle, "W_FIELD", w_field.get()));
+
+    void* scope     = nullptr;
+    void* field_ptr = nullptr;
+    EXPECT_PLUME_CODE_FAILURE(plume_data_write_scope_begin(data_handle, "W_FIELD", &scope, &field_ptr));
+    EXPECT(scope == nullptr);
+
+    // An unknown parameter must also yield an error code, not a crash.
+    EXPECT_PLUME_CODE_FAILURE(plume_data_write_scope_begin(data_handle, "DOES_NOT_EXIST", &scope, &field_ptr));
+    EXPECT(scope == nullptr);
+
+    EXPECT_PLUME_CODE_SUCCESS(plume_data_delete_handle(data_handle));
     EXPECT_PLUME_CODE_SUCCESS(plume_finalise());
 }
 

--- a/tests/api/test_writeback_fapi.F90
+++ b/tests/api/test_writeback_fapi.F90
@@ -13,6 +13,7 @@ TESTSUITE( test_writeback_fapi_suite )
 
 TEST( test_writeback_fapi )
 use iso_c_binding, only: c_int, c_double, c_null_char
+use atlas_module
 use plume_module
 use plume_data_module
 use plume_manager_module
@@ -27,15 +28,20 @@ type(plume_data)     :: data
 integer(c_int)    :: fort_w_int          = 0
 real(c_double)    :: fort_w_double_check = 0.0d0
 
+type(atlas_Field)       :: fort_w_field
+integer(c_int), pointer :: fort_w_field_data(:)
+
 character(len=500) :: mgr_conf_str
 character(len=:), allocatable :: pending_str
 
+call atlas_library%initialise()
 call plume_check(plume_initialise())
 
 ! Offer writable parameters (model side)
 call plume_check(protocol%initialise())
 call plume_check(protocol%offer_int_writable("FORT_W_INT",    "always", "writable int"))
 call plume_check(protocol%offer_double_writable("FORT_W_DOUBLE", "always", "writable double"))
+call plume_check(protocol%offer_atlas_field_writable("FORT_W_FIELD", "always", "writable atlas field"))
 
 mgr_conf_str = '{' // &
 '"write-back-policy": "single-writer", ' // &
@@ -46,7 +52,8 @@ mgr_conf_str = '{' // &
 '        "parameters": [' // &
 '            [' // &
 '                {"name": "FORT_W_INT",    "type": "INT",    "writable": true},' // &
-'                {"name": "FORT_W_DOUBLE", "type": "DOUBLE", "writable": true}' // &
+'                {"name": "FORT_W_DOUBLE", "type": "DOUBLE", "writable": true},' // &
+'                {"name": "FORT_W_FIELD",  "type": "ATLAS_FIELD", "writable": true}' // &
 '            ]' // &
 '        ],' // &
 '        "core-config": {}' // &
@@ -61,9 +68,18 @@ call plume_check(data%initialise())
 ! Writable params can be either provided (model-owned memory) or created (Plume-owned). Both are tested here.
 call plume_check(data%provide_int("FORT_W_INT",       fort_w_int))         ! model-owned
 call plume_check(data%create_double("FORT_W_DOUBLE",  real(0.0d0, kind=c_double)))  ! Plume-owned
+
+! Provided (model-owned) atlas field seeded with known values; the write-back must land in this buffer in place.
+fort_w_field = atlas_Field("FORT_W_FIELD", atlas_integer(), (/3/))
+call fort_w_field%data(fort_w_field_data)
+fort_w_field_data(1) = 1_c_int
+fort_w_field_data(2) = 2_c_int
+fort_w_field_data(3) = 3_c_int
+call plume_check(data%provide_atlas_field_shared("FORT_W_FIELD", fort_w_field))
+
 call plume_check(manager%feed_plugins(data))
 
-! Run the plugin — it writes FORT_W_INT=99 and FORT_W_DOUBLE=1.23
+! Run the plugin — it writes FORT_W_INT=99, FORT_W_DOUBLE=1.23 and FORT_W_FIELD=(100,200,300)
 call plume_check(manager%run())
 
 ! Verify value written to model-owned memory via raw pointer
@@ -73,24 +89,33 @@ FCTEST_CHECK(fort_w_int == 99_c_int)
 call plume_check(data%get_double("FORT_W_DOUBLE", fort_w_double_check))
 FCTEST_CHECK(abs(fort_w_double_check - real(1.23d0, kind=c_double)) < 1.0d-10)
 
+! Verify the provided atlas field was written in place: the model's own field handle sees the new values.
+FCTEST_CHECK(fort_w_field_data(1) == 100_c_int)
+FCTEST_CHECK(fort_w_field_data(2) == 200_c_int)
+FCTEST_CHECK(fort_w_field_data(3) == 300_c_int)
+
 ! Verify pending write-backs
 pending_str = data%pending_writebacks()
 FCTEST_CHECK(index(pending_str, "FORT_W_INT")    > 0)
 FCTEST_CHECK(index(pending_str, "FORT_W_DOUBLE") > 0)
+FCTEST_CHECK(index(pending_str, "FORT_W_FIELD")  > 0)
 
 ! Acknowledge each write-back
 call plume_check(data%acknowledge_writeback("FORT_W_INT"))
 call plume_check(data%acknowledge_writeback("FORT_W_DOUBLE"))
+call plume_check(data%acknowledge_writeback("FORT_W_FIELD"))
 
 ! Verify no more pending write-backs after acknowledgement
 pending_str = data%pending_writebacks()
 FCTEST_CHECK(index(pending_str, "FORT_W_INT")    == 0)
 FCTEST_CHECK(index(pending_str, "FORT_W_DOUBLE") == 0)
+FCTEST_CHECK(index(pending_str, "FORT_W_FIELD")  == 0)
 
 call plume_check(manager%finalise())
 call plume_check(data%finalise())
 call plume_check(protocol%finalise())
 call plume_check(plume_finalise())
+call atlas_library%finalise()
 
 END_TEST
 

--- a/tests/api/test_writeback_fapi.F90
+++ b/tests/api/test_writeback_fapi.F90
@@ -31,7 +31,13 @@ real(c_double)    :: fort_w_double_check = 0.0d0
 type(atlas_Field)       :: fort_w_field
 integer(c_int), pointer :: fort_w_field_data(:)
 
-character(len=500) :: mgr_conf_str
+type(atlas_Field)       :: fort_w_scope_field
+integer(c_int), pointer :: fort_w_scope_field_data(:)
+
+type(atlas_Field)       :: fort_w_scope_field2
+integer(c_int), pointer :: fort_w_scope_field2_data(:)
+
+character(len=800) :: mgr_conf_str
 character(len=:), allocatable :: pending_str
 
 call atlas_library%initialise()
@@ -42,6 +48,8 @@ call plume_check(protocol%initialise())
 call plume_check(protocol%offer_int_writable("FORT_W_INT",    "always", "writable int"))
 call plume_check(protocol%offer_double_writable("FORT_W_DOUBLE", "always", "writable double"))
 call plume_check(protocol%offer_atlas_field_writable("FORT_W_FIELD", "always", "writable atlas field"))
+call plume_check(protocol%offer_atlas_field_writable("FORT_W_SCOPE_FIELD", "always", "in-place scope field"))
+call plume_check(protocol%offer_atlas_field_writable("FORT_W_SCOPE_FIELD2", "always", "explicit-commit scope field"))
 
 mgr_conf_str = '{' // &
 '"write-back-policy": "single-writer", ' // &
@@ -53,7 +61,9 @@ mgr_conf_str = '{' // &
 '            [' // &
 '                {"name": "FORT_W_INT",    "type": "INT",    "writable": true},' // &
 '                {"name": "FORT_W_DOUBLE", "type": "DOUBLE", "writable": true},' // &
-'                {"name": "FORT_W_FIELD",  "type": "ATLAS_FIELD", "writable": true}' // &
+'                {"name": "FORT_W_FIELD",  "type": "ATLAS_FIELD", "writable": true},' // &
+'                {"name": "FORT_W_SCOPE_FIELD", "type": "ATLAS_FIELD", "writable": true},' // &
+'                {"name": "FORT_W_SCOPE_FIELD2", "type": "ATLAS_FIELD", "writable": true}' // &
 '            ]' // &
 '        ],' // &
 '        "core-config": {}' // &
@@ -77,9 +87,26 @@ fort_w_field_data(2) = 2_c_int
 fort_w_field_data(3) = 3_c_int
 call plume_check(data%provide_atlas_field_shared("FORT_W_FIELD", fort_w_field))
 
+! Provided (model-owned) field for the in-place scope path, seeded so the plugin's +1000 read-modify-write is checkable.
+fort_w_scope_field = atlas_Field("FORT_W_SCOPE_FIELD", atlas_integer(), (/3/))
+call fort_w_scope_field%data(fort_w_scope_field_data)
+fort_w_scope_field_data(1) = 7_c_int
+fort_w_scope_field_data(2) = 8_c_int
+fort_w_scope_field_data(3) = 9_c_int
+call plume_check(data%provide_atlas_field_shared("FORT_W_SCOPE_FIELD", fort_w_scope_field))
+
+! Provided (model-owned) field for the explicit-commit scope path, seeded so the plugin's +500 write is checkable.
+fort_w_scope_field2 = atlas_Field("FORT_W_SCOPE_FIELD2", atlas_integer(), (/3/))
+call fort_w_scope_field2%data(fort_w_scope_field2_data)
+fort_w_scope_field2_data(1) = 11_c_int
+fort_w_scope_field2_data(2) = 12_c_int
+fort_w_scope_field2_data(3) = 13_c_int
+call plume_check(data%provide_atlas_field_shared("FORT_W_SCOPE_FIELD2", fort_w_scope_field2))
+
 call plume_check(manager%feed_plugins(data))
 
 ! Run the plugin — it writes FORT_W_INT=99, FORT_W_DOUBLE=1.23 and FORT_W_FIELD=(100,200,300)
+! FORT_W_SCOPE_FIELD=(1007,1008,1009), FORT_W_SCOPE_FIELD2=(511,512,513)
 call plume_check(manager%run())
 
 ! Verify value written to model-owned memory via raw pointer
@@ -94,22 +121,39 @@ FCTEST_CHECK(fort_w_field_data(1) == 100_c_int)
 FCTEST_CHECK(fort_w_field_data(2) == 200_c_int)
 FCTEST_CHECK(fort_w_field_data(3) == 300_c_int)
 
+! Verify the scope path wrote in place through the model's own buffer (seed 7,8,9 + 1000 via RAII auto-commit).
+FCTEST_CHECK(fort_w_scope_field_data(1) == 1007_c_int)
+FCTEST_CHECK(fort_w_scope_field_data(2) == 1008_c_int)
+FCTEST_CHECK(fort_w_scope_field_data(3) == 1009_c_int)
+
+! Verify the explicit-commit scope path wrote in place (seed 11,12,13 + 500); reaching here without a crash also
+! confirms the block-exit finaliser did not double-commit/double-free the already-committed scope.
+FCTEST_CHECK(fort_w_scope_field2_data(1) == 511_c_int)
+FCTEST_CHECK(fort_w_scope_field2_data(2) == 512_c_int)
+FCTEST_CHECK(fort_w_scope_field2_data(3) == 513_c_int)
+
 ! Verify pending write-backs
 pending_str = data%pending_writebacks()
 FCTEST_CHECK(index(pending_str, "FORT_W_INT")    > 0)
 FCTEST_CHECK(index(pending_str, "FORT_W_DOUBLE") > 0)
 FCTEST_CHECK(index(pending_str, "FORT_W_FIELD")  > 0)
+FCTEST_CHECK(index(pending_str, "FORT_W_SCOPE_FIELD") > 0)
+FCTEST_CHECK(index(pending_str, "FORT_W_SCOPE_FIELD2") > 0)
 
 ! Acknowledge each write-back
 call plume_check(data%acknowledge_writeback("FORT_W_INT"))
 call plume_check(data%acknowledge_writeback("FORT_W_DOUBLE"))
 call plume_check(data%acknowledge_writeback("FORT_W_FIELD"))
+call plume_check(data%acknowledge_writeback("FORT_W_SCOPE_FIELD"))
+call plume_check(data%acknowledge_writeback("FORT_W_SCOPE_FIELD2"))
 
 ! Verify no more pending write-backs after acknowledgement
 pending_str = data%pending_writebacks()
 FCTEST_CHECK(index(pending_str, "FORT_W_INT")    == 0)
 FCTEST_CHECK(index(pending_str, "FORT_W_DOUBLE") == 0)
 FCTEST_CHECK(index(pending_str, "FORT_W_FIELD")  == 0)
+FCTEST_CHECK(index(pending_str, "FORT_W_SCOPE_FIELD") == 0)
+FCTEST_CHECK(index(pending_str, "FORT_W_SCOPE_FIELD2") == 0)
 
 call plume_check(manager%finalise())
 call plume_check(data%finalise())

--- a/tests/core/CMakeLists.txt
+++ b/tests/core/CMakeLists.txt
@@ -84,6 +84,13 @@ ecbuild_add_test( TARGET   plume_test_model_data
                     plume_plugin       
 )
 
+ecbuild_add_test( TARGET   plume_test_model_data_view_enforcement
+                  SOURCES  test_model_data_view_enforcement.cc
+                  LIBS
+                    plume_plugin_manager
+                    plume_plugin
+)
+
 ecbuild_add_test( TARGET   plume_test_atlas_model_data
                   SOURCES  test_atlas_model_data.cc
                   LIBS                    
@@ -138,7 +145,19 @@ ecbuild_add_test( TARGET   plume_test_plugin_writeback
 )
 
 ecbuild_add_test( TARGET   plume_test_writeback_atlas
-                  SOURCES  test_writeback_atlas.cc
+                  SOURCES
+                    ManagerTestAccess.h
+                    test_writeback_atlas.cc
+                  LIBS
+                    plume_plugin_manager
+                    plume_plugin
+                    eckit
+)
+
+ecbuild_add_test( TARGET   plume_test_writeback_scope
+                  SOURCES
+                    ManagerTestAccess.h
+                    test_writeback_scope.cc
                   LIBS
                     plume_plugin_manager
                     plume_plugin
@@ -154,3 +173,38 @@ ecbuild_add_test( TARGET   plume_test_plugin_params
                     plume_plugin_manager
                     eckit
 )
+
+
+# ----------------------------------------------------------------------------------------------------------------------
+# Compile-time enforcement: the value-based writeParam(name, value) overload must REJECT FieldView and
+# FieldWriter (access handles, not values) via its in-body static_assert. That rejection is a hard error.
+# ----------------------------------------------------------------------------------------------------------------------
+ecbuild_add_executable( TARGET       plume_should_not_compile_writeparam_fieldview
+                        SOURCES      should_not_compile_writeparam.cc
+                        DEFINITIONS  CHECK_FIELDVIEW
+                        LIBS         plume_plugin
+                        NOINSTALL )
+set_target_properties( plume_should_not_compile_writeparam_fieldview
+                       PROPERTIES EXCLUDE_FROM_ALL TRUE EXCLUDE_FROM_DEFAULT_BUILD TRUE )
+
+ecbuild_add_test( TARGET          plume_test_writeparam_rejects_fieldview
+                  COMMAND         ${CMAKE_COMMAND}
+                  ARGS            --build ${CMAKE_BINARY_DIR}
+                                  --target plume_should_not_compile_writeparam_fieldview
+                                  --config $<CONFIG>
+                  TEST_PROPERTIES WILL_FAIL TRUE )
+
+ecbuild_add_executable( TARGET       plume_should_not_compile_writeparam_fieldwriter
+                        SOURCES      should_not_compile_writeparam.cc
+                        DEFINITIONS  CHECK_FIELDWRITER
+                        LIBS         plume_plugin
+                        NOINSTALL )
+set_target_properties( plume_should_not_compile_writeparam_fieldwriter
+                       PROPERTIES EXCLUDE_FROM_ALL TRUE EXCLUDE_FROM_DEFAULT_BUILD TRUE )
+
+ecbuild_add_test( TARGET          plume_test_writeparam_rejects_fieldwriter
+                  COMMAND         ${CMAKE_COMMAND}
+                  ARGS            --build ${CMAKE_BINARY_DIR}
+                                  --target plume_should_not_compile_writeparam_fieldwriter
+                                  --config $<CONFIG>
+                  TEST_PROPERTIES WILL_FAIL TRUE )

--- a/tests/core/CMakeLists.txt
+++ b/tests/core/CMakeLists.txt
@@ -137,6 +137,14 @@ ecbuild_add_test( TARGET   plume_test_plugin_writeback
                     eckit
 )
 
+ecbuild_add_test( TARGET   plume_test_writeback_atlas
+                  SOURCES  test_writeback_atlas.cc
+                  LIBS
+                    plume_plugin_manager
+                    plume_plugin
+                    eckit
+)
+
 
 ecbuild_add_test( TARGET   plume_test_plugin_params
                   SOURCES

--- a/tests/core/should_not_compile_writeparam.cc
+++ b/tests/core/should_not_compile_writeparam.cc
@@ -1,0 +1,45 @@
+/*
+ * (C) Copyright 2025- ECMWF.
+ *
+ * This software is licensed under the terms of the Apache Licence Version 2.0
+ * which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * In applying this licence, ECMWF does not waive the privileges and immunities
+ * granted to it by virtue of its status as an intergovernmental organisation nor
+ * does it submit to any jurisdiction.
+ */
+
+// Compile-time enforcement fixture for the value-based writeParam(name, value) overload (PLUME-75).
+//
+// FieldView (read-only handle) and FieldWriter (scope-bound in-place handle) are access handles, NOT values to be
+// written back.
+//
+// Each variant type-checks up to the offending writeParam call; only the static_assert should stop compilation.
+
+#include <string>
+
+#include "plume/data/FieldAccess.h"
+#include "plume/data/ModelData.h"
+
+#include "atlas/array/ArrayShape.h"
+#include "atlas/array/DataType.h"
+#include "atlas/field/Field.h"
+
+void trigger() {
+    plume::data::ModelData data;
+
+#if defined(CHECK_FIELDVIEW)
+    // A FieldView (e.g. obtained from getParam) is read-only and must not be accepted as a writeParam value —
+    // the author must clone() it to a mutable atlas::Field first.
+    atlas::Field field("x", atlas::array::make_datatype<int>(), atlas::array::make_shape(1));
+    plume::data::FieldView fieldView(field);
+    data.writeParam("x", fieldView);  // MUST NOT COMPILE
+#elif defined(CHECK_FIELDWRITER)
+    // A FieldWriter is the in-place handle a WriteScope hands out; feeding it back into the value overload is a
+    // category error (it aliases the model buffer, it is not a value to copy in).
+    plume::data::WriteScope scope = data.writeParam("x");
+    data.writeParam("x", scope.field());  // MUST NOT COMPILE
+#else
+#error "Define CHECK_FIELDVIEW or CHECK_FIELDWRITER to select the rejection under test"
+#endif
+}

--- a/tests/core/test_model_data.cc
+++ b/tests/core/test_model_data.cc
@@ -16,6 +16,7 @@
 
 #include "plume/data/FieldProvider.h"
 #include "plume/data/ModelData.h"
+#include "plume/data/ModelDataView.h"
 #include "plume/data/ParameterValue.h"
 
 using namespace eckit::testing;

--- a/tests/core/test_model_data_view_enforcement.cc
+++ b/tests/core/test_model_data_view_enforcement.cc
@@ -1,0 +1,196 @@
+/*
+ * (C) Copyright 2023- ECMWF.
+ *
+ * This software is licensed under the terms of the Apache Licence Version 2.0
+ * which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * In applying this licence, ECMWF does not waive the privileges and immunities
+ * granted to it by virtue of its status as an intergovernmental organisation nor
+ * does it submit to any jurisdiction.
+ */
+
+// Compile-time enforcement fixture for the plugin/model data-access contract (PLUME-72/75).
+//
+// ModelDataView privately inherits ModelData and re-publishes (via `using`) only the plugin-legal
+// surface. The static_asserts below prove structurally that the model-only mutators are NOT reachable
+// through a ModelDataView, while the read/write-back surface IS — so a plugin that only ever holds a
+// ModelDataView cannot call updateParam/provideParam/createParam/filter. If the enforcement regresses,
+// this translation unit fails to COMPILE (the tightest possible failure signal), long before any run.
+
+#include <set>
+#include <string>
+#include <type_traits>
+
+#include "eckit/testing/Test.h"
+
+#include "atlas/array/Array.h"
+#include "atlas/array/ArrayView.h"
+#include "atlas/array/MakeView.h"
+#include "atlas/field/Field.h"
+
+#include "plume/data/FieldAccess.h"
+#include "plume/data/ModelData.h"
+#include "plume/data/ModelDataView.h"
+
+using namespace eckit::testing;
+
+namespace plume::test {
+
+using data::FieldView;
+using data::ModelData;
+using data::ModelDataView;
+
+// --- Callability detectors: `can_X<T>::value` is true if the expression X is well-formed (and
+//     accessible) for an object of type T. Access violations from private inheritance are substitution
+//     failures (C++11 DR1170), so a hidden inherited member yields false rather than a hard error. ------
+
+template <class T, class = void>
+struct can_updateParam : std::false_type {};
+template <class T>
+struct can_updateParam<T, std::void_t<decltype(std::declval<T&>().template updateParam<int>(std::string{}, 0))>>
+    : std::true_type {};
+
+template <class T, class = void>
+struct can_provideParam : std::false_type {};
+template <class T>
+struct can_provideParam<
+    T, std::void_t<decltype(std::declval<T&>().template provideParam<int>(std::string{}, std::declval<int*>()))>>
+    : std::true_type {};
+
+template <class T, class = void>
+struct can_createParam : std::false_type {};
+template <class T>
+struct can_createParam<T, std::void_t<decltype(std::declval<T&>().template createParam<int>(std::string{}, 0))>>
+    : std::true_type {};
+
+template <class T, class = void>
+struct can_filter : std::false_type {};
+template <class T>
+struct can_filter<T, std::void_t<decltype(std::declval<const T&>().filter(std::set<std::string>{}, std::string{}))>>
+    : std::true_type {};
+
+template <class T, class = void>
+struct can_getParam : std::false_type {};
+template <class T>
+struct can_getParam<T, std::void_t<decltype(std::declval<const T&>().template getParam<int>(std::string{}))>>
+    : std::true_type {};
+
+template <class T, class = void>
+struct can_writeParam : std::false_type {};
+template <class T>
+struct can_writeParam<
+    T, std::void_t<decltype(std::declval<T&>().template writeParam<int>(std::string{}, std::declval<const int&>()))>>
+    : std::true_type {};
+
+template <class T, class = void>
+struct can_hasParameter : std::false_type {};
+template <class T>
+struct can_hasParameter<T, std::void_t<decltype(std::declval<const T&>().hasParameter(std::string{}))>>
+    : std::true_type {};
+
+// Sanity: the detectors themselves are correct — the mutators ARE reachable on the full ModelData.
+static_assert(can_updateParam<ModelData>::value, "ModelData must expose updateParam");
+static_assert(can_provideParam<ModelData>::value, "ModelData must expose provideParam");
+static_assert(can_createParam<ModelData>::value, "ModelData must expose createParam");
+static_assert(can_filter<ModelData>::value, "ModelData must expose filter");
+
+// Core contract: model-only mutators are NOT reachable through the plugin-facing view.
+static_assert(!can_updateParam<ModelDataView>::value, "ModelDataView must NOT expose updateParam");
+static_assert(!can_provideParam<ModelDataView>::value, "ModelDataView must NOT expose provideParam");
+static_assert(!can_createParam<ModelDataView>::value, "ModelDataView must NOT expose createParam");
+static_assert(!can_filter<ModelDataView>::value, "ModelDataView must NOT expose filter");
+
+// Plugin-legal surface is available on BOTH the model and the view.
+static_assert(can_getParam<ModelData>::value && can_getParam<ModelDataView>::value,
+              "getParam must be reachable on ModelData and ModelDataView");
+static_assert(can_writeParam<ModelData>::value && can_writeParam<ModelDataView>::value,
+              "writeParam must be reachable on ModelData and ModelDataView");
+static_assert(can_hasParameter<ModelData>::value && can_hasParameter<ModelDataView>::value,
+              "hasParameter must be reachable on ModelData and ModelDataView");
+
+// Structural: a view cannot be sliced or cast back to its private base to reach the hidden methods.
+static_assert(!std::is_convertible<ModelDataView*, ModelData*>::value,
+              "ModelDataView* must NOT convert to ModelData* (private inheritance)");
+static_assert(!std::is_convertible<ModelDataView&, ModelData&>::value,
+              "ModelDataView& must NOT convert to ModelData& (private inheritance)");
+
+// getParam<atlas::Field> yields a read-only FieldView on the view, never a mutable atlas::Field ----------
+
+// Return-type wiring: fields become FieldView on the view; scalars are unchanged; the model path still hands back a
+// real atlas::Field.
+static_assert(
+    std::is_same_v<decltype(std::declval<const ModelDataView&>().getParam<atlas::Field>(std::string{})), FieldView>,
+    "ModelDataView::getParam<atlas::Field> must return a FieldView");
+static_assert(std::is_same_v<decltype(std::declval<const ModelDataView&>().getParam<int>(std::string{})), int>,
+              "scalar getParam on a view must be unchanged (returns by value)");
+static_assert(
+    std::is_same_v<decltype(std::declval<const ModelData&>().getParam<atlas::Field>(std::string{})), atlas::Field>,
+    "ModelData::getParam<atlas::Field> (model path) must still return a real atlas::Field");
+
+// The derived-name (level/levtype) getParam overload on the view must apply the SAME read-only wrapping. This pins the
+// second overload so it cannot silently drift from the single-argument one and leak a mutable field.
+static_assert(std::is_same_v<decltype(std::declval<const ModelDataView&>().getParam<atlas::Field>(
+                                 std::string{}, std::string{}, std::string{})),
+                             FieldView>,
+              "ModelDataView::getParam<atlas::Field>(name, level, levtype) must return a FieldView");
+static_assert(
+    std::is_same_v<
+        decltype(std::declval<const ModelDataView&>().getParam<int>(std::string{}, std::string{}, std::string{})), int>,
+    "scalar getParam(name, level, levtype) on a view must be unchanged (returns by value)");
+
+// FieldView must NOT be convertible to a mutable atlas::Field (so `atlas::Field f = getParam(...)`
+// does not compile) nor to a mutable Array&; only the read-only `const Array&` conversion exists.
+static_assert(!std::is_convertible_v<FieldView, atlas::Field>, "FieldView must NOT convert to a mutable atlas::Field");
+static_assert(!std::is_convertible_v<FieldView, atlas::array::Array&>,
+              "FieldView must NOT convert to a mutable Array&");
+static_assert(std::is_convertible_v<FieldView, const atlas::array::Array&>,
+              "FieldView must convert to a read-only const Array& (so make_view keeps working)");
+
+// clone() is the sanctioned mutable path: it yields an independent, owning atlas::Field (a deep copy).
+static_assert(std::is_same_v<decltype(std::declval<const FieldView&>().clone()), atlas::Field>,
+              "FieldView::clone() must return an owning atlas::Field deep copy");
+
+// FieldWriter is the scope-bound in-place write handle. It must be non-copyable AND non-movable so a plugin cannot
+// stash it by value and use it past the WriteScope that owns its validity flag (`auto stolen = f;` must not compile).
+using data::FieldWriter;
+static_assert(!std::is_copy_constructible_v<FieldWriter>, "FieldWriter must be non-copyable");
+static_assert(!std::is_copy_assignable_v<FieldWriter>, "FieldWriter must be non-copy-assignable");
+static_assert(!std::is_move_constructible_v<FieldWriter>, "FieldWriter must be non-movable");
+static_assert(!std::is_move_assignable_v<FieldWriter>, "FieldWriter must be non-move-assignable");
+
+// FieldWriter is the write sibling of FieldView: it DOES convert to a mutable Array& (in-place write path), but must
+// not leak a copyable atlas::Field handle that would outlive the scope and alias the model buffer unguarded.
+static_assert(std::is_convertible_v<FieldWriter&, atlas::array::Array&>,
+              "FieldWriter must convert to a mutable Array& (the in-place write path)");
+static_assert(!std::is_convertible_v<FieldWriter&, atlas::Field>,
+              "FieldWriter must NOT convert to a copyable atlas::Field handle");
+
+// Mutable-view creation is rejected structurally: because the only conversion is to const Array&, make_view<int,Rank>
+// over a FieldView resolves to the const-source overload and yields ArrayView<const int,Rank>. A mutable
+// ArrayView<int,Rank> is therefore unobtainable from a FieldView — the read-only-ness comes from the source, not the
+// caller writing `const`.
+static_assert(std::is_same_v<decltype(atlas::array::make_view<int, 1>(std::declval<const FieldView&>())),
+                             atlas::array::ArrayView<const int, 1>>,
+              "make_view<int,1> over a FieldView must yield a read-only ArrayView<const int,1>");
+
+//----------------------------------------------------------------------------------------------------------------------
+
+// A runtime case so the framework reports a passing test; it also exercises the exposed surface.
+CASE("model_data_view_exposes_only_plugin_surface") {
+    ModelData data;
+    data.createParam<int>("x", 42);
+
+    ModelDataView view = data.filter(std::set<std::string>{"x"}, "PluginA");
+
+    EXPECT(view.hasParameter("x"));
+    EXPECT_EQUAL(view.getParam<int>("x"), 42);
+    EXPECT_EQUAL(view.consumer(), std::string("PluginA"));
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+
+}  // namespace plume::test
+
+int main(int argc, char** argv) {
+    return run_tests(argc, argv);
+}

--- a/tests/core/test_writeback_atlas.cc
+++ b/tests/core/test_writeback_atlas.cc
@@ -1,0 +1,109 @@
+/*
+ * (C) Copyright 2025- ECMWF.
+ *
+ * This software is licensed under the terms of the Apache Licence Version 2.0
+ * which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * In applying this licence, ECMWF does not waive the privileges and immunities
+ * granted to it by virtue of its status as an intergovernmental organisation nor
+ * does it submit to any jurisdiction.
+ */
+#include <string>
+
+#include "eckit/testing/Test.h"
+
+#include "plume/coupling/WriteAuthorisation.h"
+#include "plume/coupling/WriteBackLedger.h"
+#include "plume/coupling/WriteBackPolicy.h"
+#include "plume/data/ModelData.h"
+
+#include "atlas/array/ArrayShape.h"
+#include "atlas/array/ArrayView.h"
+#include "atlas/array/DataType.h"
+#include "atlas/array/MakeView.h"
+#include "atlas/field/Field.h"
+
+using namespace eckit::testing;
+
+namespace plume::test {
+
+/**
+ * @brief Verifies that writing back to a model-provided Atlas field updates the model's own buffer in place.
+ *
+ * A model-provided field is not owned by Plume: `provideParam` keeps a reference-counted handle that shares the
+ * model's `FieldImpl`, so the underlying data array is the model's memory. A plugin write-back must therefore land
+ * directly in that shared buffer — mirroring the provided-scalar case, where `writeParam` writes straight through
+ * the model's raw pointer. Concretely this requires that:
+ *   - the write is observable through the model's original field handle (no read-back needed), and
+ *   - the stored implementation is preserved (the handle is not swapped for the plugin's field).
+ *
+ * The write-back lifecycle is driven directly through the ledger here (rather than the Manager/plugin machinery)
+ * to isolate the `ModelData::writeParam` semantics for a provided Atlas field. The model-facing ModelData carries
+ * an empty consumer name, so the authorisation is granted to that empty name.
+ */
+CASE("test writeback - provided atlas field is written back in place") {
+    plume::data::ModelData data;
+
+    // Model-owned field with its own atlas-allocated storage, seeded with initial values.
+    atlas::Field modelField("F", atlas::array::make_datatype<int>(), atlas::array::make_shape(4));
+    {
+        auto initView = atlas::array::make_view<int, 1>(modelField);
+        for (int i = 0; i < 4; ++i) {
+            initView(i) = i + 1;
+        }
+    }
+    data.provideParam("F", &modelField);
+
+    // Capture the model's implementation to assert the write-back preserves the handle identity.
+    const atlas::Field::Implementation* modelImpl = modelField.get();
+
+    // Confirm the field starts out carrying the initial values, so the post-write check is meaningful.
+    {
+        auto beforeView = atlas::array::make_view<int, 1>(modelField);
+        EXPECT_EQUAL(beforeView(0), 1);
+        EXPECT_EQUAL(beforeView(3), 4);
+    }
+
+    // Wire the write-back ledger directly, authorising the (empty-named) model-facing consumer to write "F".
+    WriteAuthorisation auth;
+    auth.grant("", "F");
+    coupling::WriteBackLedger ledger(auth, WriteBackPolicy::single_writer);
+    data.enrollWritebackParams(ledger, auth);
+    data.attachWritebackLedger(&ledger);
+    ledger.open();
+
+    // A plugin writes a new field carrying updated values.
+    atlas::Field pluginField("F", atlas::array::make_datatype<int>(), atlas::array::make_shape(4));
+    {
+        auto pluginView = atlas::array::make_view<int, 1>(pluginField);
+        pluginView(0) = 10;
+        pluginView(1) = 20;
+        pluginView(2) = 30;
+        pluginView(3) = 40;
+    }
+    data.writeParam<atlas::Field>("F", pluginField);
+
+    // The write must land in the model's own buffer, observable through the model's original handle, without
+    // swapping the underlying implementation.
+    EXPECT(modelField.get() == modelImpl);
+    {
+        auto afterView = atlas::array::make_view<int, 1>(modelField);
+        EXPECT_EQUAL(afterView(0), 10);
+        EXPECT_EQUAL(afterView(3), 40);
+    }
+
+    // getParam must observe the same in-place update on the same implementation.
+    atlas::Field got = data.getParam<atlas::Field>("F");
+    EXPECT(got.get() == modelImpl);
+
+    // Complete the write-back cycle cleanly before the ledger is destroyed.
+    ledger.flush();
+    data.acknowledgeWriteback("F");
+    data.detachWritebackLedger();
+}
+
+}  // namespace plume::test
+
+int main(int argc, char** argv) {
+    return run_tests(argc, argv);
+}

--- a/tests/core/test_writeback_atlas.cc
+++ b/tests/core/test_writeback_atlas.cc
@@ -9,13 +9,19 @@
  * does it submit to any jurisdiction.
  */
 #include <string>
+#include <type_traits>
 
+#include "eckit/exception/Exceptions.h"
 #include "eckit/testing/Test.h"
 
 #include "plume/coupling/WriteAuthorisation.h"
 #include "plume/coupling/WriteBackLedger.h"
 #include "plume/coupling/WriteBackPolicy.h"
+#include "plume/data/FieldAccess.h"
 #include "plume/data/ModelData.h"
+#include "plume/data/ModelDataView.h"
+
+#include "ManagerTestAccess.h"
 
 #include "atlas/array/ArrayShape.h"
 #include "atlas/array/ArrayView.h"
@@ -76,10 +82,10 @@ CASE("test writeback - provided atlas field is written back in place") {
     atlas::Field pluginField("F", atlas::array::make_datatype<int>(), atlas::array::make_shape(4));
     {
         auto pluginView = atlas::array::make_view<int, 1>(pluginField);
-        pluginView(0) = 10;
-        pluginView(1) = 20;
-        pluginView(2) = 30;
-        pluginView(3) = 40;
+        pluginView(0)   = 10;
+        pluginView(1)   = 20;
+        pluginView(2)   = 30;
+        pluginView(3)   = 40;
     }
     data.writeParam<atlas::Field>("F", pluginField);
 
@@ -99,6 +105,137 @@ CASE("test writeback - provided atlas field is written back in place") {
     // Complete the write-back cycle cleanly before the ledger is destroyed.
     ledger.flush();
     data.acknowledgeWriteback("F");
+    data.detachWritebackLedger();
+}
+
+/**
+ * @brief Verifies the plugin-facing read-modify-write path: getParam yields a read-only FieldView, FieldView::clone()
+ *        gives an independent mutable copy seeded with the current values, and writing that clone back through
+ *        writeParam lands in the model's own buffer in place.
+ *
+ * getParam<atlas::Field> on a ModelDataView must return a plume::data::FieldView (not a mutable atlas::Field),
+ * so the only way for a plugin to obtain a writable field is clone() — which is a disconnected deep copy.
+ * Mutating the clone must NOT touch the model buffer (proving the read-only guarantee is not reopened);
+ * the values reach the model only via writeParam, which copies them in place onto the model's existing FieldImpl.
+ */
+CASE("test writeback - plugin clones a FieldView, read-modify-writes, and lands in place") {
+    plume::data::ModelData data;
+
+    atlas::Field modelField("F", atlas::array::make_datatype<int>(), atlas::array::make_shape(4));
+    {
+        auto initView = atlas::array::make_view<int, 1>(modelField);
+        for (int i = 0; i < 4; ++i) {
+            initView(i) = i + 1;  // 1, 2, 3, 4
+        }
+    }
+    data.provideParam("F", &modelField);
+    const atlas::Field::Implementation* modelImpl = modelField.get();
+
+    // Wire the ledger authorising a named plugin consumer to write "F", then build the plugin-facing view.
+    WriteAuthorisation auth;
+    auth.grant("pluginA", "F");
+    coupling::WriteBackLedger ledger(auth, WriteBackPolicy::single_writer);
+    data.enrollWritebackParams(ledger, auth);
+    data.attachWritebackLedger(&ledger);
+    plume::data::ModelDataView view = data.filter(std::set<std::string>{"F"}, "pluginA");
+    ledger.open();
+
+    // getParam on the plugin-facing view yields a read-only FieldView, never a mutable atlas::Field.
+    auto fieldView = view.getParam<atlas::Field>("F");
+    static_assert(std::is_same_v<decltype(fieldView), plume::data::FieldView>,
+                  "getParam<atlas::Field> on a ModelDataView must return a FieldView");
+
+    // The read-only guarantee comes from the FieldView itself, NOT from the caller writing `const`. Request a view
+    // with a non-const element type (int): because a FieldView only converts to `const atlas::array::Array&`,
+    // make_view resolves to the const-source overload and still yields an ArrayView<const int, ...>. A mutable
+    // ArrayView<int, ...> is unobtainable from a FieldView — that is what makes the read path immutable.
+    {
+        auto ro = atlas::array::make_view<int, 1>(fieldView);  // note: int, NOT const int
+        static_assert(std::is_same_v<decltype(ro), atlas::array::ArrayView<const int, 1>>,
+                      "make_view<int,1> over a FieldView must yield a read-only ArrayView<const int,1>");
+        EXPECT_EQUAL(ro(0), 1);
+        EXPECT_EQUAL(ro(3), 4);
+    }
+
+    // clone() gives an independent, mutable deep copy seeded with the current values.
+    atlas::Field work = fieldView.clone();
+    EXPECT(work.get() != modelImpl);  // distinct implementation — shares nothing with the model
+    {
+        auto wv = atlas::array::make_view<int, 1>(work);
+        for (int i = 0; i < 4; ++i) {
+            wv(i) += 100;  // 101, 102, 103, 104
+        }
+    }
+
+    // Mutating the clone must NOT touch the model buffer before write-back (proves deep-copy independence).
+    {
+        auto stillOriginal = atlas::array::make_view<int, 1>(modelField);
+        EXPECT_EQUAL(stillOriginal(0), 1);
+        EXPECT_EQUAL(stillOriginal(3), 4);
+    }
+
+    // Write the modified clone back through the authorised plugin path.
+    view.writeParam<atlas::Field>("F", work);
+
+    // The write lands in the model's own buffer, in place, without swapping the implementation.
+    EXPECT(modelField.get() == modelImpl);
+    {
+        auto afterView = atlas::array::make_view<int, 1>(modelField);
+        EXPECT_EQUAL(afterView(0), 101);
+        EXPECT_EQUAL(afterView(1), 102);
+        EXPECT_EQUAL(afterView(2), 103);
+        EXPECT_EQUAL(afterView(3), 104);
+    }
+
+    ledger.flush();
+    data.acknowledgeWriteback("F");
+    data.detachWritebackLedger();
+}
+
+/**
+ * @brief The value-based writeParam(name, value) write-back must reject an atlas::Field whose shape or datatype does
+ *        not match the stored field, via the writeFieldInPlace guard (eckit::UserError). The failure must also be
+ *        reported to the ledger (the slot goes to error) rather than silently corrupting the model buffer.
+ */
+CASE("test writeback - value writeParam rejects a shape/datatype-mismatched field and reports the error") {
+    plume::data::ModelData data;
+
+    atlas::Field modelField("F", atlas::array::make_datatype<int>(), atlas::array::make_shape(4));
+    {
+        auto initView = atlas::array::make_view<int, 1>(modelField);
+        for (int i = 0; i < 4; ++i) {
+            initView(i) = i + 1;
+        }
+    }
+    data.provideParam("F", &modelField);
+
+    WriteAuthorisation auth;
+    auth.grant("", "F");
+    coupling::WriteBackLedger ledger(auth, WriteBackPolicy::single_writer);
+    data.enrollWritebackParams(ledger, auth);
+    data.attachWritebackLedger(&ledger);
+    ledger.open();
+
+    // Wrong shape: 2 elements vs the stored 4 → UserError, and the failure is recorded on the ledger.
+    atlas::Field wrongShape("F", atlas::array::make_datatype<int>(), atlas::array::make_shape(2));
+    EXPECT_THROWS_AS(data.writeParam<atlas::Field>("F", wrongShape), eckit::UserError);
+    EXPECT(ledger.hasErrors());
+
+    // The model buffer must be untouched by the rejected write.
+    {
+        auto after = atlas::array::make_view<int, 1>(modelField);
+        EXPECT_EQUAL(after(0), 1);
+        EXPECT_EQUAL(after(3), 4);
+    }
+    ManagerTestAccess::forceLedgerReset(ledger);
+
+    // Wrong datatype: double vs the stored int (same shape) → UserError.
+    ledger.open();
+    atlas::Field wrongType("F", atlas::array::make_datatype<double>(), atlas::array::make_shape(4));
+    EXPECT_THROWS_AS(data.writeParam<atlas::Field>("F", wrongType), eckit::UserError);
+    EXPECT(ledger.hasErrors());
+
+    ManagerTestAccess::forceLedgerReset(ledger);
     data.detachWritebackLedger();
 }
 

--- a/tests/core/test_writeback_atlas.cc
+++ b/tests/core/test_writeback_atlas.cc
@@ -216,10 +216,13 @@ CASE("test writeback - value writeParam rejects a shape/datatype-mismatched fiel
     data.attachWritebackLedger(&ledger);
     ledger.open();
 
+    EXPECT_NOT(data.isUpdated("F"));
+
     // Wrong shape: 2 elements vs the stored 4 → UserError, and the failure is recorded on the ledger.
     atlas::Field wrongShape("F", atlas::array::make_datatype<int>(), atlas::array::make_shape(2));
     EXPECT_THROWS_AS(data.writeParam<atlas::Field>("F", wrongShape), eckit::UserError);
     EXPECT(ledger.hasErrors());
+    EXPECT_NOT(data.isUpdated("F"));
 
     // The model buffer must be untouched by the rejected write.
     {
@@ -234,6 +237,13 @@ CASE("test writeback - value writeParam rejects a shape/datatype-mismatched fiel
     atlas::Field wrongType("F", atlas::array::make_datatype<double>(), atlas::array::make_shape(4));
     EXPECT_THROWS_AS(data.writeParam<atlas::Field>("F", wrongType), eckit::UserError);
     EXPECT(ledger.hasErrors());
+    
+    EXPECT_NOT(data.isUpdated("F"));
+    ManagerTestAccess::forceLedgerReset(ledger);
+    ledger.open();
+    atlas::Field validReplacement("F", atlas::array::make_datatype<int>(), atlas::array::make_shape(4));
+    EXPECT_NO_THROW(data.writeParam<atlas::Field>("F", validReplacement));
+    EXPECT(data.isUpdated("F"));
 
     ManagerTestAccess::forceLedgerReset(ledger);
     data.detachWritebackLedger();

--- a/tests/core/test_writeback_scope.cc
+++ b/tests/core/test_writeback_scope.cc
@@ -1,0 +1,334 @@
+/*
+ * (C) Copyright 2025- ECMWF.
+ *
+ * This software is licensed under the terms of the Apache Licence Version 2.0
+ * which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * In applying this licence, ECMWF does not waive the privileges and immunities
+ * granted to it by virtue of its status as an intergovernmental organisation nor
+ * does it submit to any jurisdiction.
+ */
+#include <stdexcept>
+#include <string>
+#include <utility>
+
+#include "eckit/exception/Exceptions.h"
+#include "eckit/testing/Test.h"
+
+#include "plume/coupling/WriteAuthorisation.h"
+#include "plume/coupling/WriteBackLedger.h"
+#include "plume/coupling/WriteBackPolicy.h"
+#include "plume/data/FieldAccess.h"
+#include "plume/data/ModelData.h"
+#include "plume/data/ModelDataView.h"
+
+#include "ManagerTestAccess.h"
+
+#include "atlas/array/Array.h"
+#include "atlas/array/ArrayShape.h"
+#include "atlas/array/ArrayView.h"
+#include "atlas/array/DataType.h"
+#include "atlas/array/MakeView.h"
+#include "atlas/field/Field.h"
+
+using namespace eckit::testing;
+
+namespace plume::test {
+
+namespace {
+
+/// Builds a model with a single int field "F" seeded 1,2,3,4 and its own atlas-allocated storage.
+atlas::Field makeSeededField() {
+    atlas::Field field("F", atlas::array::make_datatype<int>(), atlas::array::make_shape(4));
+    auto view = atlas::array::make_view<int, 1>(field);
+    for (int i = 0; i < 4; ++i) {
+        view(i) = i + 1;  // 1, 2, 3, 4
+    }
+    return field;
+}
+
+/// Reads back the int field and checks every element against `expected`, element by element.
+void expectFieldValues(const atlas::Field& field, std::initializer_list<int> expected) {
+    auto view = atlas::array::make_view<int, 1>(field);
+    int i     = 0;
+    for (int value : expected) {
+        EXPECT_EQUAL(view(i), value);
+        ++i;
+    }
+}
+
+/// Common write-back wiring shared by every CASE: a ModelData holding the seeded int field "F", an authorisation
+/// granting the listed consumers write access to "F", and a ledger enrolled (and, by default, attached) under the
+/// given policy. `ledger.open()` and view filtering stay in each CASE so their ordering remains explicit.
+struct WritebackHarness {
+    plume::data::ModelData data;
+    atlas::Field modelField                       = makeSeededField();
+    const atlas::Field::Implementation* modelImpl = modelField.get();
+    WriteAuthorisation auth;
+    coupling::WriteBackLedger ledger;
+
+    WritebackHarness(std::initializer_list<std::string> consumers,
+                     WriteBackPolicy policy = WriteBackPolicy::single_writer, bool attach = true) :
+        ledger(auth, policy) {
+        data.provideParam("F", &modelField);
+        for (const auto& consumer : consumers) {
+            auth.grant(consumer, "F");
+        }
+        data.enrollWritebackParams(ledger, auth);
+        if (attach) {
+            data.attachWritebackLedger(&ledger);
+        }
+    }
+
+    void attachLedger() { data.attachWritebackLedger(&ledger); }
+
+    plume::data::ModelDataView view(const std::string& consumer) {
+        return data.filter(std::set<std::string>{"F"}, consumer);
+    }
+
+    /// Successful teardown: flush the ledger, acknowledge the write-back, detach.
+    void flushAndDetach() {
+        ledger.flush();
+        data.acknowledgeWriteback("F");
+        data.detachWritebackLedger();
+    }
+
+    /// Failure teardown: force the ledger back to a clean state, detach.
+    void resetAndDetach() {
+        ManagerTestAccess::forceLedgerReset(ledger);
+        data.detachWritebackLedger();
+    }
+};
+
+}  // namespace
+
+CASE("test writeback scope - manual WriteScope writes in place and preserves the FieldImpl") {
+    // Model-facing ModelData carries an empty consumer name; authorise that name to write "F".
+    WritebackHarness h({""});
+    h.ledger.open();
+
+    {
+        plume::data::WriteScope scope   = h.data.writeParam("F");
+        plume::data::FieldWriter writer = scope.field();
+        auto v = atlas::array::make_view<int, 1>(writer);  // MUTABLE view aliasing the model buffer
+        for (int i = 0; i < 4; ++i) {
+            v(i) *= 10;  // 10, 20, 30, 40 — in place
+        }
+        scope.commit();
+    }
+
+    // The mutation is observable through the model's original handle, on the same implementation.
+    EXPECT_EQUAL(h.modelField.get(), h.modelImpl);
+    expectFieldValues(h.modelField, {10, 20, 30, 40});
+    EXPECT(!h.ledger.hasErrors());
+
+    h.flushAndDetach();
+}
+
+CASE("test writeback scope - callable overload commits on normal return, in place") {
+    WritebackHarness h({"pluginA"});
+    plume::data::ModelDataView view = h.view("pluginA");
+    h.ledger.open();
+
+    view.writeParam("F", [](plume::data::FieldWriter& f) {
+        auto v = atlas::array::make_view<int, 1>(f);
+        for (int i = 0; i < 4; ++i) {
+            v(i) += 100;  // 101, 102, 103, 104
+        }
+    });
+
+    EXPECT_EQUAL(h.modelField.get(), h.modelImpl);
+    expectFieldValues(h.modelField, {101, 102, 103, 104});
+    EXPECT(!h.ledger.hasErrors());
+
+    h.flushAndDetach();
+}
+
+CASE("test writeback scope - callable overload aborts and reports to the ledger when the body throws") {
+    WritebackHarness h({"pluginA"});
+    plume::data::ModelDataView view = h.view("pluginA");
+    h.ledger.open();
+
+    EXPECT(!h.ledger.hasErrors());
+    EXPECT_THROWS_AS(view.writeParam("F",
+                                     [](plume::data::FieldWriter& f) {
+                                         auto v = atlas::array::make_view<int, 1>(f);
+                                         v(0)   = -1;  // partial in-place write before the failure
+                                         throw std::runtime_error("author failed mid-write");
+                                     }),
+                     std::runtime_error);
+
+    // The scope was destroyed without commit() → the abort was reported to the ledger.
+    EXPECT(h.ledger.hasErrors());
+
+    EXPECT_EQUAL(h.modelField.get(), h.modelImpl);
+    expectFieldValues(h.modelField, {-1, 2, 3, 4});  // index 0 written, seeds 2,3,4 untouched
+
+    h.resetAndDetach();
+}
+
+CASE("test writeback scope - FieldWriter used after commit throws BadValue") {
+    WritebackHarness h({""});
+    h.ledger.open();
+
+    {
+        plume::data::WriteScope scope   = h.data.writeParam("F");
+        plume::data::FieldWriter writer = scope.field();
+        {
+            auto v = atlas::array::make_view<int, 1>(writer);  // valid while the scope is open
+            v(0)   = 7;
+        }
+        scope.commit();  // poisons the handle (valid_ = false), scope still alive
+
+        EXPECT_THROWS_AS(([&writer]() {
+                             atlas::array::Array& a = writer;
+                             (void)a;
+                         }()),
+                         eckit::BadValue);
+    }
+
+    h.flushAndDetach();
+}
+
+CASE("test writeback scope - writeParam(name) error branches: no ledger, missing param, non-field") {
+    // Do not attach the ledger yet: the first branch checks the pre-attach failure.
+    WritebackHarness h({""}, WriteBackPolicy::single_writer, /*attach=*/false);
+    h.data.createParam<int>("scalar", 7);
+
+    // No ledger attached yet → BadValue.
+    EXPECT_THROWS_AS(h.data.writeParam("F"), eckit::BadValue);
+
+    h.attachLedger();
+    h.ledger.open();
+
+    // Unknown parameter → BadParameter.
+    EXPECT_THROWS_AS(h.data.writeParam("does-not-exist"), eckit::BadParameter);
+    // Non-field parameter → BadValue (in-place scope is atlas::Field-only; use writeParam(name, value) instead).
+    EXPECT_THROWS_AS(h.data.writeParam("scalar"), eckit::BadValue);
+
+    h.data.detachWritebackLedger();
+}
+
+CASE("test writeback scope - moved-from WriteScope is neutralised") {
+    WritebackHarness h({""});
+    h.ledger.open();
+
+    {
+        plume::data::WriteScope src = h.data.writeParam("F");  // staged
+        plume::data::WriteScope dst = std::move(src);          // move-construct; src must be neutralised
+        {
+            plume::data::FieldWriter writer = dst.field();
+            auto v                          = atlas::array::make_view<int, 1>(writer);
+            v(0)                            = 5;
+        }
+        dst.commit();
+        // src goes out of scope here uncommitted-by-construction; if the move did not neutralise it, its destructor
+        // would report a spurious abort to the ledger.
+    }
+
+    EXPECT(!h.ledger.hasErrors());  // proves the moved-from src did not report an abort
+
+    h.flushAndDetach();
+}
+
+CASE("test writeback scope - callable overload accepts an Array& body") {
+    WritebackHarness h({"pluginA"});
+    plume::data::ModelDataView view = h.view("pluginA");
+    h.ledger.open();
+
+    view.writeParam("F", [](atlas::array::Array& arr) {
+        auto v = atlas::array::make_view<int, 1>(arr);
+        for (int i = 0; i < 4; ++i) {
+            v(i) = 5;
+        }
+    });
+    expectFieldValues(h.modelField, {5, 5, 5, 5});
+    EXPECT(!h.ledger.hasErrors());
+
+    h.flushAndDetach();
+}
+
+CASE("test writeback scope - callable overload accepts a generic auto& body") {
+    WritebackHarness h({"pluginA"});
+    plume::data::ModelDataView view = h.view("pluginA");
+    h.ledger.open();
+
+    view.writeParam("F", [](auto& f) {
+        auto v = atlas::array::make_view<int, 1>(f);
+        for (int i = 0; i < 4; ++i) {
+            v(i) += 100;
+        }
+    });
+    EXPECT_EQUAL(h.modelField.get(), h.modelImpl);
+    expectFieldValues(h.modelField, {101, 102, 103, 104});
+    EXPECT(!h.ledger.hasErrors());
+
+    h.flushAndDetach();
+}
+
+CASE("test writeback scope - write-back policy is enforced through the WriteScope path") {
+    // Single-writer: the second plugin's scope staging violates the policy and throws.
+    {
+        WritebackHarness h({"A", "B"}, WriteBackPolicy::single_writer);
+        plume::data::ModelDataView viewA = h.view("A");
+        plume::data::ModelDataView viewB = h.view("B");
+        h.ledger.open();
+
+        plume::data::WriteScope scopeA = viewA.writeParam("F");  // A stages
+        EXPECT_THROWS(viewB.writeParam("F"));                    // B violates single-writer during staging
+        scopeA.commit();
+
+        h.resetAndDetach();
+    }
+
+    // Multi-writer: two authorised plugins may each open and commit an in-place scope.
+    {
+        WritebackHarness h({"A", "B"}, WriteBackPolicy::multi_writer);
+        plume::data::ModelDataView viewA = h.view("A");
+        plume::data::ModelDataView viewB = h.view("B");
+        h.ledger.open();
+
+        {
+            plume::data::WriteScope scopeA = viewA.writeParam("F");
+            scopeA.commit();
+        }
+        {
+            plume::data::WriteScope scopeB = viewB.writeParam("F");  // allowed under multi-writer
+            scopeB.commit();
+        }
+        EXPECT(!h.ledger.hasErrors());
+
+        h.flushAndDetach();
+    }
+}
+
+CASE("test writeback scope - destroying a filtered view does not detach the model ledger") {
+    WritebackHarness h({"", "pluginA"});  // model-facing "" consumer + plugin consumer
+    h.ledger.open();
+
+    {
+        // A filtered view borrows the ledger; when it goes out of scope its base destructor must be a no-op w.r.t.
+        // the shared ledger (ownsLedger_ == false).
+        plume::data::ModelDataView view = h.view("pluginA");
+        EXPECT(view.hasParameter("F"));
+    }
+
+    // If the view had wrongly detached, this model-facing write would throw "ledger not attached".
+    atlas::Field replacement("F", atlas::array::make_datatype<int>(), atlas::array::make_shape(4));
+    {
+        auto v = atlas::array::make_view<int, 1>(replacement);
+        for (int i = 0; i < 4; ++i) {
+            v(i) = 42;
+        }
+    }
+    EXPECT_NO_THROW(h.data.writeParam<atlas::Field>("F", replacement));
+    expectFieldValues(h.modelField, {42, 42, 42, 42});
+
+    h.flushAndDetach();
+}
+
+}  // namespace plume::test
+
+int main(int argc, char** argv) {
+    return run_tests(argc, argv);
+}

--- a/tests/core/test_writeback_scope.cc
+++ b/tests/core/test_writeback_scope.cc
@@ -12,6 +12,7 @@
 #include <string>
 #include <utility>
 
+#include "eckit/config/LocalConfiguration.h"
 #include "eckit/exception/Exceptions.h"
 #include "eckit/testing/Test.h"
 
@@ -19,8 +20,10 @@
 #include "plume/coupling/WriteBackLedger.h"
 #include "plume/coupling/WriteBackPolicy.h"
 #include "plume/data/FieldAccess.h"
+#include "plume/data/FieldProvider.h"
 #include "plume/data/ModelData.h"
 #include "plume/data/ModelDataView.h"
+#include "plume/data/ParameterValue.h"
 
 #include "ManagerTestAccess.h"
 
@@ -32,6 +35,49 @@
 #include "atlas/field/Field.h"
 
 using namespace eckit::testing;
+
+namespace plume::field_provider {
+
+/**
+ * @class DummyFieldStrategy
+ * @brief Test-only strategy setting the target field to the source field's values scaled by 10.
+ */
+class DummyFieldStrategy : public UpdateStrategy {
+private:
+    AtlasFieldObservablePtr source_;
+    AtlasFieldObserverPtr target_;
+
+public:
+    DummyFieldStrategy(AtlasFieldObservablePtr source, AtlasFieldObserverPtr target) :
+        source_(source), target_(target) {}
+
+    void update() override {
+        auto source = source_.lock();
+        auto target = target_.lock();
+        ASSERT(source && target);
+
+        auto srcView = atlas::array::make_view<int, 1>(source->get());
+        auto tgtView = atlas::array::make_view<int, 1>(target->getSettableField());
+        for (atlas::idx_t i = 0; i < srcView.shape(0); ++i) {
+            tgtView(i) = srcView(i) * 10;
+        }
+        target->setUpdated(true);
+    }
+};
+
+/**
+ * @brief Specialisation of UpdateStrategyTraits for DummyFieldStrategy. Test-only, no config/param args.
+ */
+template <>
+struct UpdateStrategyTraits<DummyFieldStrategy> {
+    static constexpr const char* name = "dummy_field";
+    static constexpr std::array<const char*, 0> configArgs{};
+    static constexpr std::array<const char*, 0> paramArgs{};
+    static constexpr std::array<std::array<const char*, 0>, 0> requiredParams{{}};
+    using Args = std::tuple<AtlasFieldObservablePtr, AtlasFieldObserverPtr>;
+};
+
+}  // namespace plume::field_provider
 
 namespace plume::test {
 
@@ -325,6 +371,99 @@ CASE("test writeback scope - destroying a filtered view does not detach the mode
     expectFieldValues(h.modelField, {42, 42, 42, 42});
 
     h.flushAndDetach();
+}
+
+// ---- Observer notification on write-back ----
+
+/// Attaches a "F;dummy;00" derived parameter observing "F" via DummyFieldStrategy.
+void attachDummyObserver(plume::data::ModelData& data) {
+    data.registerStrategy<plume::field_provider::DummyFieldStrategy>();
+    eckit::LocalConfiguration cfg;
+    cfg.set("name", "F");
+    cfg.set("levtype", "dummy");
+    cfg.set("level", "00");
+    data.createParam<atlas::Field>("dummy_field", cfg);
+}
+
+CASE("test writeback scope - value-based writeParam notifies an actively observing derived parameter") {
+    WritebackHarness h({""});
+    attachDummyObserver(h.data);
+    h.ledger.open();
+
+    EXPECT_NOT(h.data.isUpdated("F"));
+    EXPECT_NOT(h.data.isUpdated("F;dummy;00"));
+    // "F;dummy;00" is created as a clone of "F" (seeded 1,2,3,4); the strategy has not run yet.
+    expectFieldValues(h.data.getParam<atlas::Field>("F;dummy;00"), {1, 2, 3, 4});
+
+    atlas::Field replacement("F", atlas::array::make_datatype<int>(), atlas::array::make_shape(4));
+    {
+        auto v = atlas::array::make_view<int, 1>(replacement);
+        for (int i = 0; i < 4; ++i) {
+            v(i) = i + 5;  // 5, 6, 7, 8
+        }
+    }
+
+    EXPECT_NO_THROW(h.data.writeParam<atlas::Field>("F", replacement));
+
+    // The write-back target itself is marked updated...
+    EXPECT(h.data.isUpdated("F"));
+    // ...and its actively observing derived parameter was synchronously notified and recomputed.
+    EXPECT(h.data.isUpdated("F;dummy;00"));
+    expectFieldValues(h.data.getParam<atlas::Field>("F;dummy;00"), {50, 60, 70, 80});
+
+    h.flushAndDetach();
+}
+
+CASE("test writeback scope - WriteScope commit() notifies an actively observing derived parameter") {
+    WritebackHarness h({""});
+    attachDummyObserver(h.data);
+    h.ledger.open();
+
+    EXPECT_NOT(h.data.isUpdated("F"));
+    EXPECT_NOT(h.data.isUpdated("F;dummy;00"));
+
+    {
+        plume::data::WriteScope scope   = h.data.writeParam("F");
+        plume::data::FieldWriter writer = scope.field();
+        auto v = atlas::array::make_view<int, 1>(writer);  // MUTABLE view aliasing the model buffer
+        for (int i = 0; i < 4; ++i) {
+            v(i) *= 10;  // 10, 20, 30, 40 — in place
+        }
+        scope.commit();
+    }
+
+    EXPECT(h.data.isUpdated("F"));
+    EXPECT(h.data.isUpdated("F;dummy;00"));
+    expectFieldValues(h.data.getParam<atlas::Field>("F;dummy;00"), {100, 200, 300, 400});
+
+    h.flushAndDetach();
+}
+
+CASE("test writeback scope - WriteScope destroyed without commit() does not notify observers") {
+    WritebackHarness h({""});
+    attachDummyObserver(h.data);
+    h.ledger.open();
+
+    EXPECT_NOT(h.data.isUpdated("F"));
+    EXPECT_NOT(h.data.isUpdated("F;dummy;00"));
+
+    {
+        plume::data::WriteScope scope   = h.data.writeParam("F");
+        plume::data::FieldWriter writer = scope.field();
+        auto v = atlas::array::make_view<int, 1>(writer);
+        for (int i = 0; i < 4; ++i) {
+            v(i) *= 10;
+        }
+        // scope destroyed here without commit() — abort path, reports to the ledger.
+    }
+
+    EXPECT_NOT(h.data.isUpdated("F"));
+    EXPECT_NOT(h.data.isUpdated("F;dummy;00"));
+    EXPECT(h.ledger.hasErrors());
+    // Strategy never ran; "F;dummy;00" still holds its initial clone of the seeded "F" values.
+    expectFieldValues(h.data.getParam<atlas::Field>("F;dummy;00"), {1, 2, 3, 4});
+
+    h.resetAndDetach();
 }
 
 }  // namespace plume::test


### PR DESCRIPTION
### Description

This PR addresses the vulnerabilities highlighted in the [run pendant PR](https://github.com/ecmwf/plume/pull/31) of the write-back feature. It makes the write-back mechanism impossible to bypass accidentally. Plugins interfaces might remain unchanged if they only used the atlas view acquisition idiom, but both extreme event and wind farm plugins need a patch to support this (PRs to be opened when this stabilises).

Here is a readable plan detailing the implemented design, request access if necessary: [Plan](https://ecmwf-my.sharepoint.com/:u:/g/personal/clara_ducher_ecmwf_int/IQAiFPbvjHxVQrFSXL9sA4gcAfaLj6BtHQQt3gcXaYFb5LM?e=bcVkdf)

It depends on [PR#32](https://github.com/ecmwf/plume/pull/32) (merged) and the cascade of PRs in the two-way-coupling branches.

The important changes are the introduction of a FieldAccess file which exposes FieldView and FieldWriter classes to wrap atlas fields in true read-only and writable modes, and a ModelDataView which is the new output of the model data filter method, it is a "downgraded" version of the model data which does not have any of the data creation and direct mutation methods. The introduction of the ModelDataView is I think the opportunity to challenge the shared parameter ownership model, as Dom pointed out, and I captured it in a new ticket (PLUME-82). See the detailed plan or class docstrings for detailed rationale behind these new structures.

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/Contributor-License-Agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 
